### PR TITLE
force Content-Type to json and serialize data before send

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -200,9 +200,8 @@ Client.prototype._performRequest = function (action, path, data, query) {
     rq.query(query);
   }
 
-  if (data) {
-    rq.send(data);
-  }
+  rq.type('json');
+  rq.send(JSON.stringify(data));
 
   if (this._secret) {
     rq.set('Authorization', secretHeader(this._secret));

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -60,8 +60,35 @@ describe('query', function () {
     });
   });
 
-  // Basic forms
+  it('echo values', function () {
+    var pInteger = client.query(10).then(function (res) {
+      assert.equal(res, 10);
+    });
 
+    var pNumber = client.query(3.14).then(function (res) {
+      assert.equal(res, 3.14);
+    });
+
+    var pString = client.query('string').then(function (res) {
+      assert.equal(res, 'string');
+    });
+
+    var pObject = client.query({a: 1, b: 'string', c: 3.14, d: null}).then(function (res) {
+      assert.deepEqual(res, {a: 1, b: 'string', c: 3.14, d: null});
+    });
+
+    var pArray = client.query([1, 'string', 3.14, null]).then(function (res) {
+      assert.deepEqual(res, [1, 'string', 3.14, null]);
+    });
+
+    var pNull = client.query(null).then(function (res) {
+      assert.equal(res, null);
+    });
+
+    return Promise.all([pInteger, pNumber, pString, pObject, pArray, pNull]);
+  })
+
+  // Basic forms
   it('at', function () {
     var client = util.client();
 


### PR DESCRIPTION
This PR forces the `Content-Type` of request to `application/json` and serialize data to string before passing it to superagent so the library don't have to infer the data type.

This fixes the case when we just send primitive types and expect faunadb to echo these values.