### PR TITLE
Accept lambdas for let expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 1.0.2-SNAPSHOT
+## 1.1.0-SNAPSHOT
+- Accept lambdas at Let function
 
 ## 1.0.1 (March 21, 2017)
 - Fix wrap of Select's default parameter in order to allow other types rather

--- a/src/query.js
+++ b/src/query.js
@@ -64,6 +64,18 @@ function At(timestamp, expr) {
  * */
 function Let(vars, in_expr) {
   arity.exact(2, arguments);
+
+  if (in_expr instanceof Function) {
+    var expr = in_expr.apply(null, annotate(in_expr).map(function(name) {
+      return Var(name);
+    }));
+
+    return new Expr({
+      let: wrapValues(vars),
+      in: expr
+    });
+  }
+
   return new Expr({ let: wrapValues(vars), in: wrap(in_expr) });
 }
 

--- a/src/query.js
+++ b/src/query.js
@@ -66,7 +66,7 @@ function Let(vars, in_expr) {
   arity.exact(2, arguments);
 
   if (in_expr instanceof Function) {
-    var expr = in_expr.apply(null, annotate(in_expr).map(function(name) {
+    var expr = in_expr.apply(null, Object.keys(vars).map(function(name) {
       return Var(name);
     }));
 

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -112,7 +112,10 @@ describe('query', function () {
   });
 
   it('let/var', function () {
-    return assertQuery(query.Let({ x: 1 }, query.Var('x')), 1);
+    return Promise.all([
+      assertQuery(query.Let({ x: 1 }, query.Var('x')), 1),
+      assertQuery(query.Let({ x: 1, y: 2 }, function(x, y) { return [x, y] }), [1, 2])
+    ]);
   });
 
   it('if', function () {


### PR DESCRIPTION
This is a syntax sugar proposal. It avoid `q.Var` expressions when using `q.Let`.

Before:
```javascript
q.Let({ x: 1, y: 2 }, q.Add(q.Var("x"), q.Var("y")))
```

Now:
```javascript
q.Let({ x: 1, y: 2 }, (x, y) => q.Add(x, y))
```