### PR TITLE
Fix wrap of literal object for lambda form of let expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 1.1.1-SNAPSHOT
+- Fix wrap of literal objects for lambda form of let expression
 
 ## 1.1.0 (March 22, 2017)
 - Accept lambdas at Let function

--- a/src/query.js
+++ b/src/query.js
@@ -66,14 +66,9 @@ function Let(vars, in_expr) {
   arity.exact(2, arguments);
 
   if (in_expr instanceof Function) {
-    var expr = in_expr.apply(null, Object.keys(vars).map(function(name) {
+    in_expr = in_expr.apply(null, Object.keys(vars).map(function(name) {
       return Var(name);
     }));
-
-    return new Expr({
-      let: wrapValues(vars),
-      in: expr
-    });
   }
 
   return new Expr({ let: wrapValues(vars), in: wrap(in_expr) });

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -114,7 +114,8 @@ describe('query', function () {
   it('let/var', function () {
     return Promise.all([
       assertQuery(query.Let({ x: 1 }, query.Var('x')), 1),
-      assertQuery(query.Let({ x: 1, y: 2 }, function(x, y) { return [x, y] }), [1, 2])
+      assertQuery(query.Let({ x: 1, y: 2 }, function(x, y) { return [x, y] }), [1, 2]),
+      assertQuery(query.Let({ x: 1, y: 2 }, function(x, y) { return { a: x, b: y } }), { a: 1, b: 2 })
     ]);
   });
 


### PR DESCRIPTION
Returning a object was not possible. I've missed a `wrap` at the return of the lambda function.