### PR TITLE
Fix typescript declaration file to include default types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 1.1.2-SNAPSHOT
+- Fix typescript declaration file to include default types
 
 ## 1.1.1 (March 28, 2017)
 - Fix wrap of literal objects for lambda form of let expression

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,8 @@
+export { default as Client } from './src/types/Client';
+export { default as Expr } from './src/types/Expr';
+export { default as PageHelper } from './src/types/PageHelper';
+export { default as RequestResult } from './src/types/RequestResult';
+
 export * from './src/types/Client';
 export * from './src/types/errors';
 export * from './src/types/Expr';


### PR DESCRIPTION
Fixes: #130 

Context: Typescript `export * from "./file"` exports everything except for the `default` export. Therefore, `Client` is not available to the typescript compiler, although present at runtime.