### PR TITLE
CI-12: Add dockerfile for running tests in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+esdoc
+lib
+node_modules
+npm-debug.log
+testConfig.json
+typings/
+*.iml
+*.swp
+.idea/
+.vscode/
+faunadb*.tgz
+doc/
+dist/
+coverage/
+.git/
+.gitignore

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,26 @@
+# Take in a runtime image to use for the base system
+# Expects alpine-based image
+ARG RUNTIME_IMAGE
+
+# Use the docker image provided via build arg
+FROM $RUNTIME_IMAGE
+
+# Install the libraries we need for dockerize
+RUN apk add --no-cache curl
+
+# Copy in the dockerize utility
+ARG DOCKERIZE_VERSION=0.6.0
+RUN curl -sL https://github.com/jwilder/dockerize/releases/download/v$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-v$DOCKERIZE_VERSION.tar.gz | tar -xzC /usr/local/bin
+
+# Copy project into the image
+COPY . /fauna/faunadb-js
+
+# Shift over to the project and install the dependencies
+WORKDIR /fauna/faunadb-js
+RUN npm install
+
+# Define the default variables for the tests
+ENV FAUNA_ROOT_KEY=secret FAUNA_DOMAIN=db.fauna.com FAUNA_SCHEME=https FAUNA_PORT=443
+
+# Run the tests (after target database is up)
+ENTRYPOINT dockerize -wait "$FAUNA_SCHEME://$FAUNA_DOMAIN:$FAUNA_PORT/ping" -timeout 30s npm run test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+RUNTIME_IMAGE ?= node:6-alpine
+DOCKER_RUN_FLAGS = -it --rm
+
+ifdef FAUNA_ROOT_KEY
+DOCKER_RUN_FLAGS += -e FAUNA_ROOT_KEY=$(FAUNA_ROOT_KEY)
+endif
+
+ifdef FAUNA_DOMAIN
+DOCKER_RUN_FLAGS += -e FAUNA_DOMAIN=$(FAUNA_DOMAIN)
+endif
+
+ifdef FAUNA_SCHEME
+DOCKER_RUN_FLAGS += -e FAUNA_SCHEME=$(FAUNA_SCHEME)
+endif
+
+ifdef FAUNA_PORT
+DOCKER_RUN_FLAGS += -e FAUNA_PORT=$(FAUNA_PORT)
+endif
+
+docker-test:
+	docker build -f Dockerfile.test -t faunadb-js-test:latest --build-arg RUNTIME_IMAGE=$(RUNTIME_IMAGE) .
+	docker run $(DOCKER_RUN_FLAGS) faunadb-js-test:latest

--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ will make cleanup of test databases as easy as removing the parent database.
 See the [FaunaDB Multitenancy Tutorial](https://fauna.com/tutorials/multitenant) for more
 information about nested databases.
 
+Alternatively, tests can be run via a Docker container with
+`FAUNA_ROOT_KEY="your-cloud-secret" make docker-test` (an alternate
+Alpine-based NodeJS image can be provided via `RUNTIME_IMAGE`).
+
 ### Documentation
 
 * `npm run doc` will generate JSDoc documentation for the project.


### PR DESCRIPTION
Works in Jenkins atm, though the checkmarks and the colors aren't working in the output (but it's still readable).