### PR TITLE
Add typescript to dev deps, fix typedefs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5250,6 +5250,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
+      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
+      "dev": true
+    },
     "uglify-js": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.10.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "browser-test-linux": "karma start browserTest.conf.js --browsers Chrome,Firefox",
     "browser-test-remote": "karma start mobileTest.conf.js"
   },
-  "typings": "index.ts.d",
+  "types": "index.d.ts",
   "dependencies": {
     "base64-js": "^1.2.0",
     "btoa-lite": "^1.0.0",
@@ -55,6 +55,7 @@
     "karma-safari-launcher": "^1.0.0",
     "karma-spec-reporter": "^0.0.31",
     "mocha": "^4.0.1",
+    "typescript": "^2.6.1",
     "uglify-js": "^3.1.10",
     "watchify": "^3.7.0"
   }

--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -14,14 +14,14 @@ export interface ClientConfig {
 export default class Client {
   constructor(opts?: ClientConfig);
 
-  query(expr: Expr): Promise<Object>;
+  query(expr: Expr): Promise<object>;
   paginate(expr: Expr): PageHelper;
 
-  get(path: string, query?: Object): Promise<Object>;
-  post(path: string, data: Object): Promise<Object>;
-  put(path: string, data: Object): Promise<Object>;
-  patch(path: string, data: Object): Promise<Object>;
-  delete(path: string): Promise<Object>;
+  get(path: string, query?: object): Promise<object>;
+  post(path: string, data: object): Promise<object>;
+  put(path: string, data: object): Promise<object>;
+  patch(path: string, data: object): Promise<object>;
+  delete(path: string): Promise<object>;
 
   ping(scope?: string, timeout?: number): Promise<string>;
 }

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -1,3 +1,3 @@
 export default class Expr {
-  constructor(obj: Object);
+  constructor(obj: object);
 }

--- a/src/types/PageHelper.d.ts
+++ b/src/types/PageHelper.d.ts
@@ -3,14 +3,14 @@ import Expr from "./Expr";
 import {Lambda} from "./query";
 
 export default class PageHelper {
-  constructor(client: Client, set: Expr, params?: Object);
+  constructor(client: Client, set: Expr, params?: object);
 
   map(lambda: Lambda): PageHelper;
   filter(lambda: Lambda): PageHelper;
 
-  each(lambda: (Object) => void): Promise<void>;
-  eachReverse(lambda: (Object) => void): Promise<void>;
+  each(lambda: (page: object) => void): Promise<void>;
+  eachReverse(lambda: (page: object) => void): Promise<void>;
 
-  previousPage(): Promise<Object>;
-  nextPage(): Promise<Object>;
+  previousPage(): Promise<object>;
+  nextPage(): Promise<object>;
 }

--- a/src/types/RequestResult.d.ts
+++ b/src/types/RequestResult.d.ts
@@ -4,12 +4,12 @@ export default class RequestResult {
   constructor(client: Client,
               method: string,
               path: string,
-              query: Object,
-              requestContent: Object,
+              query: object,
+              requestContent: object,
               responseRaw: string,
-              responseContent: Object,
+              responseContent: object,
               statusCode: number,
-              responseHeaders: Object,
+              responseHeaders: object,
               startTime: Date,
               endTime: Date
   );

--- a/src/types/errors.d.ts
+++ b/src/types/errors.d.ts
@@ -2,7 +2,7 @@ import RequestResult from "./RequestResult";
 
 export module errors {
   export class FaunaError extends Error {
-    constructor(message: String);
+    constructor(message: string);
 
     name: string;
     message: string;
@@ -16,7 +16,7 @@ export module errors {
     constructor(requestResult: RequestResult);
 
     requestResult: RequestResult;
-    errors(): Object;
+    errors(): object;
   }
 
   export class BadRequest extends FaunaHttpError {}

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -1,6 +1,6 @@
 import Expr from "./Expr";
 
-type ExprVal = (Expr|string|number|boolean|Object);
+type ExprVal = (Expr|string|number|boolean|object);
 type ExprArg = (ExprVal|Array<ExprVal>);
 export type Lambda = (...vars: any[]) => Expr;
 
@@ -26,7 +26,7 @@ export module query {
 
   export function Get(ref: ExprArg, ts?: ExprArg): Expr;
   export function KeyFromSecret(secret: ExprArg): Expr;
-  export function Paginate(set: ExprArg, opts?: Object): Expr;
+  export function Paginate(set: ExprArg, opts?: object): Expr;
   export function Exists(ref: ExprArg, ts?: ExprArg): Expr;
 
   export function Create(class_ref: ExprArg, params?: ExprArg): Expr;

--- a/src/types/values.d.ts
+++ b/src/types/values.d.ts
@@ -2,7 +2,7 @@ import Expr from './Expr';
 
 export module values {
   export class Value extends Expr {
-    toJSON(): Object;
+    toJSON(): object;
     inspect(): string;
   }
 
@@ -47,6 +47,6 @@ export module values {
   }
 
   export class Query extends Value {
-    constructor(value: Object);
+    constructor(value: object);
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,7 @@
         "sourceMap": false
     },
     "files": [
-      "index.d.ts",
-      "typings/index.d.ts"
+      "index.d.ts"
     ],
     "exclude": [
         "node_modules"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3205,6 +3205,10 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
+
 uglify-js@^2.6:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"


### PR DESCRIPTION
There may be some further improvements we can make to our typedefs. But this gives us the ability to run tsc on our typedefs as part of our build, and, also makes our typedefs work with modern typescript.