### PR TITLE
Set api version to 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.1.3-SNAPSHOT
 - Adds support for @query type (user defined functions)
+- Set Fauna Api version to 2.0
 
 ## 1.1.2 (July 06, 2017)
 - Fix typescript declaration file to include default types

--- a/src/Client.js
+++ b/src/Client.js
@@ -207,6 +207,8 @@ Client.prototype._performRequest = function (action, path, data, query) {
     rq.set('Authorization', secretHeader(this._secret));
   }
 
+  rq.set('X-FaunaDB-API-Version', '2.0');
+
   rq.timeout(this._timeout);
 
   return new Promise(function (resolve, reject) {

--- a/test/clientLogger_test.js
+++ b/test/clientLogger_test.js
@@ -43,7 +43,7 @@ describe('clientLogger', function () {
       }
 
       assert.equal(readLine(), '  Response JSON: {');
-      assert.equal(readLine(), '    "resource": "Scope global is OK"');
+      assert.equal(readLine(), '    "resource": "Scope write is OK"');
       assert.equal(readLine(), '  }');
       assert.match(readLine(), /^  Response \(200\): Network latency \d+ms$/);
     });


### PR DESCRIPTION
this creates the branch `release-1.x` right before we introduce recursive references and set to the version 2.1.