### PR TITLE
Adds backward support for string references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Adds `ngram` function
 - Adds `is_empty` and `is_nonempty` functions
 - Provide a raw view of the query in the RequestResult
+- Adds backward support for old references
 
 ## 2.0.0 (March 19, 2018)
 - Adds support for @query type (user defined functions)

--- a/src/_json.js
+++ b/src/_json.js
@@ -22,6 +22,22 @@ function json_parse(_, val) {
   } else if ('@ref' in val) {
     var ref = val['@ref'];
 
+    if (typeof ref === 'string') {
+      var parts = ref.split('/');
+
+      var ref_parsed = values.Native.fromName(parts[0]);
+
+      if (parts.length > 1) {
+        ref_parsed = new values.Ref(parts[1], ref_parsed);
+      }
+
+      if (parts.length > 2) {
+        ref_parsed = new values.Ref(parts[2], ref_parsed);
+      }
+
+      return ref_parsed;
+    }
+
     if (!('class' in ref) && !('database' in ref)) {
       return values.Native.fromName(ref['id']);
     }

--- a/test/values_test.js
+++ b/test/values_test.js
@@ -30,6 +30,20 @@ describe('Values', function() {
     assert.throws(function() { new Ref(); }, errors.InvalidValue, 'id cannot be null or undefined');
   });
 
+  it('parse string ref', function () {
+    assert.deepEqual(json.parseJSON('{"@ref":"classes"}'), values.Native.CLASSES);
+    assert.deepEqual(json.parseJSON('{"@ref":"classes/widgets"}'), new Ref('widgets', values.Native.CLASSES));
+    assert.deepEqual(json.parseJSON('{"@ref":"classes/widgets/123"}'), new Ref('123', new Ref('widgets', values.Native.CLASSES)));
+
+    assert.deepEqual(json.parseJSON('{"@ref":"databases"}'), values.Native.DATABASES);
+    assert.deepEqual(json.parseJSON('{"@ref":"databases/widgets"}'), new Ref('widgets', values.Native.DATABASES));
+    assert.deepEqual(json.parseJSON('{"@ref":"databases/widgets/123"}'), new Ref('123', new Ref('widgets', values.Native.DATABASES)));
+
+    assert.deepEqual(json.parseJSON('{"@ref":"indexes"}'), values.Native.INDEXES);
+    assert.deepEqual(json.parseJSON('{"@ref":"indexes/widgets"}'), new Ref('widgets', values.Native.INDEXES));
+    assert.deepEqual(json.parseJSON('{"@ref":"indexes/widgets/123"}'), new Ref('123', new Ref('widgets', values.Native.INDEXES)));
+  });
+
   it('serializes expr', function() {
     var expr = new Expr({ some: 'stringField', num: 2 });
     assert.equal(json.toJSON(expr), '{"some":"stringField","num":2}');


### PR DESCRIPTION
This adds support for the parser to convert string refs to the new recursive refs. The rationale is that users might have persisted old references, and if they upgrade to the latest version of the drivers, they won't be able to load those refs