### PR TITLE
Keep JSON request string stored at RequestResult

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -116,12 +116,12 @@ Client.prototype._execute = function (action, path, data, query) {
 
   var startTime = Date.now();
   var self = this;
-  return this._performRequest(action, path, data, query).then(function (response) {
+  return this._performRequest(action, path, data, query).then(function (response, rawQuery) {
     var endTime = Date.now();
     var responseObject = json.parseJSON(response.text);
     var requestResult = new RequestResult(
       self,
-      action, path, query, JSON.stringify(data),
+      action, path, query, rawQuery, data,
       response.text, responseObject, response.status, response.header,
       startTime, endTime);
 
@@ -140,8 +140,9 @@ Client.prototype._performRequest = function (action, path, data, query) {
     rq.query(query);
   }
 
+  var rawQuery = JSON.stringify(data);
   rq.type('json');
-  rq.send(JSON.stringify(data));
+  rq.send(rawQuery);
 
   if (this._secret) {
     rq.set('Authorization', secretHeader(this._secret));
@@ -161,7 +162,7 @@ Client.prototype._performRequest = function (action, path, data, query) {
           !(error.response.status >= 400 && error.response.status <= 599)) {
         reject(error);
       } else {
-        resolve(result);
+        resolve(result, rawQuery);
       }
     });
   });

--- a/src/RequestResult.js
+++ b/src/RequestResult.js
@@ -12,6 +12,8 @@
  *   The path that was queried. Relative to the client's domain.
  * @param {string} query
  *   URL query parameters. Only set if `method` is "GET".
+ * @param {Object} requestRaw
+ *   The JSON request string.
  * @param {Object} requestContent
  *   The request data.
  * @param {string} responseRaw
@@ -28,7 +30,7 @@
  *   The time the response was received by the client.
  * @constructor
  */
-function RequestResult(client, method, path, query, requestContent, responseRaw, responseContent, statusCode, responseHeaders, startTime, endTime) {
+function RequestResult(client, method, path, query, requestRaw, requestContent, responseRaw, responseContent, statusCode, responseHeaders, startTime, endTime) {
   /** @type {Client} */
   this.client = client;
 
@@ -44,6 +46,9 @@ function RequestResult(client, method, path, query, requestContent, responseRaw,
    * @type {object}
    */
   this.query = query;
+
+  /** @type {string} */
+  this.requestRaw = requestRaw;
 
   /** @type {object} */
   this.requestContent = requestContent;

--- a/src/types/RequestResult.d.ts
+++ b/src/types/RequestResult.d.ts
@@ -5,6 +5,7 @@ export default class RequestResult {
               method: string,
               path: string,
               query: object,
+              requestRaw: string,
               requestContent: object,
               responseRaw: string,
               responseContent: object,


### PR DESCRIPTION
The logger tests are failing. I realized that by using `JSON.stringify` we prevent it from pretty print requests to FaunaDB. Also, we were doing JSON serialization twice. I've split the raw JSON request from the executed query so the that logger can pretty print the query while the default node inspector can show the raw query string for debugging purpose.