### PR TITLE
Pretty print Fauna objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Bug fix: Typescript functions that receive lambda should support lambdas created
   by `Lambda()` function.
 - Adds `to_string`, `to_number`, `to_time`, and `to_date` functions
+- Pretty print Fauna objects
 
 ## 2.0.2 (March 28, 2018)
 - Bug fix: functions with optional scope parameter were failing when scope was

--- a/src/Expr.js
+++ b/src/Expr.js
@@ -15,4 +15,46 @@ Expr.prototype.toJSON = function() {
   return this.raw;
 };
 
+var varArgsFunctions = ['Do', 'Call', 'Union', 'Intersection', 'Difference', 'Equals', 'Add', 'Multiply', 'Subtract', 'Divide', 'Modulo', 'LT', 'LTE', 'GT', 'GTE', 'And', 'Or'];
+var specialCases = {
+  is_nonempty: 'is_non_empty',
+  lt: 'LT',
+  lte: 'LTE',
+  gt: 'GT',
+  gte: 'GTE'
+};
+
+var exprToString = function(expr, caller) {
+  if (expr instanceof Expr)
+    expr = expr.raw;
+
+  if (typeof expr === 'string')
+    return '"' + expr + '"';
+
+  if (typeof expr === 'number')
+    return expr.toString();
+
+  if (Array.isArray(expr)) {
+    var array = expr.map(function(item) { return exprToString(item); }).join(', ');
+
+    return varArgsFunctions.includes(caller) ? array : '[' + array + ']';
+  }
+
+  var keys = Object.keys(expr);
+  var fn = keys[0];
+
+  if (fn === 'object')
+    return '{' + Object.keys(expr.object).map(function(k) { return k + ': ' + exprToString(expr.object[k])}).join(', ') + '}';
+
+  if (fn in specialCases)
+    fn = specialCases[fn];
+
+  fn = fn.split('_').map(function(str) { return str.charAt(0).toUpperCase() + str.slice(1); }).join('');
+
+  var args = Object.values(expr).map(function(v) { return exprToString(v, fn)}).join(', ');
+  return fn + '(' + args + ')';
+};
+
+Expr.toString = exprToString;
+
 module.exports = Expr;

--- a/src/values.js
+++ b/src/values.js
@@ -304,7 +304,7 @@ function Query(value) {
 util.inherits(Query, Value);
 
 wrapToString(Query, function() {
-  return 'Query(' + stringify(this.value) + ')';
+  return 'Query(' + Expr.toString(this.value) + ')';
 });
 
 /** @ignore */

--- a/test/values_test.js
+++ b/test/values_test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var util = require('util');
 var assert = require('chai').assert;
 var errors = require('../src/errors');
 var json = require('../src/_json');
@@ -119,5 +120,38 @@ describe('Values', function() {
     var test_query_json = '{"@query":{"lambda":"x","expr":{"var":"x"}}}';
     assert.equal(json.toJSON(test_query), test_query_json);
     assert.deepEqual(json.parseJSON(test_query_json), test_query);
+  });
+
+  it('pretty print', function() {
+    var assertPrint = function(value, expected) {
+      assert.equal(expected, util.inspect(value, {depth: null}));
+      assert.equal(expected, value.toString());
+    };
+
+    assertPrint(new Ref('cls', values.Native.CLASSES), 'Class("cls")');
+    assertPrint(new Ref('db', values.Native.DATABASES), 'Database("db")');
+    assertPrint(new Ref('idx', values.Native.INDEXES), 'Index("idx")');
+    assertPrint(new Ref('fn', values.Native.FUNCTIONS), 'Function("fn")');
+    assertPrint(new Ref('key', values.Native.KEYS), 'Ref(Keys(), "key")');
+
+    assertPrint(values.Native.CLASSES, 'Classes()');
+    assertPrint(values.Native.DATABASES, 'Databases()');
+    assertPrint(values.Native.INDEXES, 'Indexes()');
+    assertPrint(values.Native.FUNCTIONS, 'Functions()');
+    assertPrint(values.Native.KEYS, 'Keys()');
+
+    var db = new Ref("db", values.Native.DATABASES);
+    assertPrint(new Ref('cls', values.Native.CLASSES, db), 'Class("cls", Database("db"))');
+    assertPrint(new Ref('db', values.Native.DATABASES, db), 'Database("db", Database("db"))');
+    assertPrint(new Ref('idx', values.Native.INDEXES, db), 'Index("idx", Database("db"))');
+    assertPrint(new Ref('fn', values.Native.FUNCTIONS, db), 'Function("fn", Database("db"))');
+    assertPrint(new Ref('key', values.Native.KEYS, db), 'Ref(Keys(Database("db")), "key")');
+
+    assertPrint(new FaunaTime('1970-01-01T00:00:00.123456789Z'), 'Date("1970-01-01T00:00:00.123456789Z")');
+    assertPrint(new FaunaDate('1970-01-01'), 'Date("1970-01-01")');
+
+    assertPrint(new SetRef({'match': new Ref('idx', values.Native.INDEXES)}), 'SetRef({ match: Index("idx") })');
+    assertPrint(new Bytes('1234'), 'Bytes("1234")');
+    assertPrint(new Query({'lambda': 'x', 'expr': {'var': 'x'}}), 'Query({ lambda: \'x\', expr: { var: \'x\' } })');
   });
 });

--- a/test/values_test.js
+++ b/test/values_test.js
@@ -6,6 +6,7 @@ var errors = require('../src/errors');
 var json = require('../src/_json');
 var Expr = require('../src/Expr');
 var values = require('../src/values');
+var q = require('../src/query');
 
 var FaunaDate = values.FaunaDate,
   FaunaTime = values.FaunaTime,
@@ -122,12 +123,12 @@ describe('Values', function() {
     assert.deepEqual(json.parseJSON(test_query_json), test_query);
   });
 
-  it('pretty print', function() {
-    var assertPrint = function(value, expected) {
-      assert.equal(expected, util.inspect(value, {depth: null}));
-      assert.equal(expected, value.toString());
-    };
+  var assertPrint = function(value, expected) {
+    assert.equal(expected, util.inspect(value, {depth: null}));
+    assert.equal(expected, value.toString());
+  };
 
+  it('pretty print', function() {
     assertPrint(new Ref('cls', values.Native.CLASSES), 'Class("cls")');
     assertPrint(new Ref('db', values.Native.DATABASES), 'Database("db")');
     assertPrint(new Ref('idx', values.Native.INDEXES), 'Index("idx")');
@@ -152,6 +153,125 @@ describe('Values', function() {
 
     assertPrint(new SetRef({'match': new Ref('idx', values.Native.INDEXES)}), 'SetRef({ match: Index("idx") })');
     assertPrint(new Bytes('1234'), 'Bytes("1234")');
-    assertPrint(new Query({'lambda': 'x', 'expr': {'var': 'x'}}), 'Query({ lambda: \'x\', expr: { var: \'x\' } })');
+  });
+
+  it('pretty print Query', function() {
+    assertPrint(new Query(q.Lambda('x', q.Var('x'))), 'Query(Lambda("x", Var("x")))');
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.If(q.GT(q.Var('x'), q.Var('y')), 'x > y', 'x <= y'))),
+      'Query(Lambda(["x", "y"], If(GT(Var("x"), Var("y")), "x > y", "x <= y")))'
+    );
+    assertPrint(
+      new Query(q.Lambda('ref', q.Select(['data', 'name'], q.Get(q.Var('ref'))))),
+      'Query(Lambda("ref", Select(["data", "name"], Get(Var("ref")))))'
+    );
+
+    //returns object
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], {sum: q.Add(q.Var('x'), q.Var('y')), product: q.Multiply(q.Var('x'), q.Var('y'))})),
+      'Query(Lambda(["x", "y"], {sum: Add(Var("x"), Var("y")), product: Multiply(Var("x"), Var("y"))}))'
+    );
+
+    //returns array
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], [q.Add(q.Var('x'), q.Var('y')), q.Multiply(q.Var('x'), q.Var('y'))])),
+      'Query(Lambda(["x", "y"], [Add(Var("x"), Var("y")), Multiply(Var("x"), Var("y"))]))'
+    );
+
+    //underscored names
+    assertPrint(
+      new Query(q.Lambda('ref', q.SelectAll(['data', 'name'], q.Get(q.Var('ref'))))),
+      'Query(Lambda("ref", SelectAll(["data", "name"], Get(Var("ref")))))'
+    );
+    assertPrint(
+      new Query(q.Lambda('coll', q.IsEmpty(q.Var('coll')))),
+      'Query(Lambda("coll", IsEmpty(Var("coll"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda('secret', q.KeyFromSecret(q.Var('secret')))),
+      'Query(Lambda("secret", KeyFromSecret(Var("secret"))))'
+    );
+
+    //special case
+    assertPrint(
+      new Query(q.Lambda('coll', q.IsNonEmpty(q.Var('coll')))),
+      'Query(Lambda("coll", IsNonEmpty(Var("coll"))))'
+    );
+
+    //vararg functions
+    assertPrint(
+      new Query(q.Lambda('x', q.Do(q.Var('x'), q.Var('x')))),
+      'Query(Lambda("x", Do(Var("x"), Var("x"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda('ref', q.Call(q.Var('ref'), 1, 2, 3))),
+      'Query(Lambda("ref", Call(Var("ref"), 1, 2, 3)))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.Union(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], Union(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.Intersection(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], Intersection(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.Difference(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], Difference(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.Equals(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], Equals(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.Add(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], Add(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.Multiply(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], Multiply(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.Subtract(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], Subtract(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.Divide(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], Divide(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.Modulo(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], Modulo(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.LT(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], LT(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.LTE(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], LTE(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.GT(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], GT(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.GTE(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], GTE(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.And(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], And(Var("x"), Var("y"))))'
+    );
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.Or(q.Var('x'), q.Var('y')))),
+      'Query(Lambda(["x", "y"], Or(Var("x"), Var("y"))))'
+    );
+
+    //nested varargs
+    assertPrint(
+      new Query(q.Lambda(['x', 'y'], q.Add(q.Var('x'), q.Add(q.Var('y'), 1)))),
+      'Query(Lambda(["x", "y"], Add(Var("x"), Add(Var("y"), 1))))'
+    );
   });
 });


### PR DESCRIPTION
Here are examples of the output generated by this change:
```javascript
Database("sub-db", Database("db"))
Index("spells_by_element_with_name")
Class("spells")
Class("cls", Database("db"))
SetRef({ match: Index("all_spells") })
Ref(Class("spells"), "201377948995944972")
Bytes("1234")
Date("2018-07-20T22:12:51.443072Z")
Date("2018-01-01")

{ ref: Function("fn", Database("db")),
  ts: 1532123046028578,
  name: 'fn',
  body: Query({ lambda: 'x', expr: { var: 'x' } }) }

Ref(Keys(), "159541672656502790")
```