### PR TITLE
make client.query generic

### DIFF
--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -14,7 +14,7 @@ export interface ClientConfig {
 export default class Client {
   constructor(opts?: ClientConfig);
 
-  query(expr: Expr): Promise<object>;
+  query<T = object>(expr: Expr): Promise<T>;
   paginate(expr: Expr): PageHelper;
   ping(scope?: string, timeout?: number): Promise<string>;
 }


### PR DESCRIPTION
Enables type information to be provided for query results.


```ts
client.query<IQueryResponse>(query).then(...)
```