### PR TITLE
Use agent with keepAlive option in Node.js

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -13,6 +13,9 @@ var util = require('./_util');
 var PageHelper = require('./PageHelper');
 var Promise = require('es6-promise').Promise;
 
+var isNodeEnv = typeof window === 'undefined' && typeof self === 'undefined';
+var keepAliveAgent = isNodeEnv ? new require('https').Agent({ keepAlive: true }) : undefined;
+
 /**
  * The callback that will be executed after every completed request.
  *
@@ -169,6 +172,10 @@ Client.prototype._execute = function (action, path, data, query) {
 
 Client.prototype._performRequest = function (action, path, data, query) {
   var rq = request(action, this._baseUrl + '/' + path);
+  if (keepAliveAgent) {
+    rq.agent(keepAliveAgent);
+  }
+
   if (query) {
     rq.query(query);
   }

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -27,6 +27,7 @@ export module query {
   export function Append(elements: ExprArg, collection: ExprArg): Expr;
   export function IsEmpty(collection: ExprArg): Expr;
   export function IsNonEmpty(collection: ExprArg): Expr;
+  export function Merge(...args: ExprArg[]): Expr;
 
   export function Get(ref: ExprArg, ts?: ExprArg): Expr;
   export function KeyFromSecret(secret: ExprArg): Expr;


### PR DESCRIPTION
Subsequent queries are much faster, as requests are reusing the TLS connection.