### PR TITLE
Fix index typing issue

### DIFF
--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -1,6 +1,6 @@
 import Expr from './Expr'
 
-type ExprVal = Expr | string | number | boolean | object
+type ExprVal = Expr | string | number | boolean | { [key: string]: any }
 type ExprArg = ExprVal | Array<ExprVal>
 export type Lambda = (...vars: any[]) => Expr
 


### PR DESCRIPTION
# Overview
This PR fixes a ts typing issue by changing `ExprVal`'s `object` to:
```ts
{
  [key: string]: any;
}
```


## Why?
Right now, if you run something like this:
```ts
q.CreateIndex({
  name: "posts_by_date",
  source: q.Class("posts"),
  values: [{ field: ["data", "published_on"] }]
})
```

Typescript will complain:
```
Types of property 'values' are incompatible.
  Type '{ field: string[]; }[]' is not assignable to type '() => IterableIterator<ExprVal>'.
    Type '{ field: string[]; }[]' provides no match for the signature '(): IterableIterator<ExprVal>'.
```


I'm _pretty sure_ this is happening because the primitive type `object` matches an array:

```ts
// dummy.ts
function myFunction(foo: object) {}

myFunction({ hey: "there" }) // passes
myFunction([1,2,3])          // passes
myFunction("string")         // fails
```

And our current typing looks like this:
```ts
// query.d.ts
type ExprVal = Expr | string | number | boolean | object;
type ExprArg = ExprVal | Array<ExprVal>;
```

So when Typescript encounters our user's input, it's not sure if it's an array or a "real" object. To figure out, it checks the `Array<ExprVal>` to see if it matches. 

Which it appears to because of the `values` property:
```ts
// lib.es2015.iterable.d.ts
interface Array<T> {
    /** Iterator */
    [Symbol.iterator](): IterableIterator<T>;

    /**
     * Returns an iterable of key, value pairs for every entry in the array
     */
    entries(): IterableIterator<[number, T]>;

    /**
     * Returns an iterable of keys in the array
     */
    keys(): IterableIterator<number>;

    /**
     * Returns an iterable of values in the array
     */
    values(): IterableIterator<T>;
}
```

But, the input doesn't have the iterator `[Symbol.iterator](): IterableIterator<T>;`, so Typescript thinks you're trying to create an array, but complains that you didn't fill in the rest of the properties. 

So replacing `object` with `{ [key:string]:any }` is specific enough to get hit before the `Array<ExprVal>`, which fixes the type error. 

I think. I'm still fairly new to Typescript. 

