### PR TITLE
FE-323

### DIFF
--- a/src/Expr.js
+++ b/src/Expr.js
@@ -57,7 +57,7 @@ var exprToString = function(expr, caller) {
   var type = typeof expr
 
   if (type === 'string') {
-    return '"' + expr + '"'
+    return JSON.stringify(expr)
   }
 
   if (type === 'symbol' || type === 'number' || type === 'boolean') {

--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -3,13 +3,14 @@ import PageHelper from './PageHelper'
 import RequestResult from './RequestResult'
 
 export interface ClientConfig {
+  secret: string
   domain?: string
   scheme?: 'http' | 'https'
   port?: number
-  secret: string
   timeout?: number
   observer?: (res: RequestResult, client: Client) => void
   keepAlive?: boolean
+  headers?: { [key: string]: string | number }
 }
 
 export interface QueryOptions {

--- a/src/types/errors.d.ts
+++ b/src/types/errors.d.ts
@@ -10,7 +10,7 @@ export module errors {
 
   export class InvalidValue extends FaunaError {}
 
-  export class FaunaHttpError extends FaunaError {
+  export class FaunaHTTPError extends FaunaError {
     static raiseForStatusCode(requestResult: RequestResult): void
 
     constructor(requestResult: RequestResult)
@@ -19,11 +19,11 @@ export module errors {
     errors(): object
   }
 
-  export class BadRequest extends FaunaHttpError {}
-  export class Unauthorized extends FaunaHttpError {}
-  export class PermissionDenied extends FaunaHttpError {}
-  export class NotFound extends FaunaHttpError {}
-  export class MethodNotAllowed extends FaunaHttpError {}
-  export class InternalError extends FaunaHttpError {}
-  export class UnavailableError extends FaunaHttpError {}
+  export class BadRequest extends FaunaHTTPError {}
+  export class Unauthorized extends FaunaHTTPError {}
+  export class PermissionDenied extends FaunaHTTPError {}
+  export class NotFound extends FaunaHTTPError {}
+  export class MethodNotAllowed extends FaunaHTTPError {}
+  export class InternalError extends FaunaHTTPError {}
+  export class UnavailableError extends FaunaHTTPError {}
 }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1076,16 +1076,12 @@ describe('query', () => {
         var documentRef = result.ref
         return client
           .query(query.Login(documentRef, { password: 'sekrit' }))
-          .then(function(result2) {
+          .then(async function(result2) {
             var secret = result2.secret
             var instanceClient = util.getClient({ secret: secret })
 
-            var self = new values.Ref(
-              'self',
-              new values.Ref('widgets', Native.COLLECTIONS)
-            )
             return instanceClient
-              .query(query.Select('ref', query.Get(self)))
+              .query(query.Select('ref', query.Get(documentRef)))
               .then(function(result3) {
                 expect(result3).toEqual(documentRef)
 


### PR DESCRIPTION
### Notes
* Fix toExpr on fauna driver
  * Related to VSCode extension issue when the extension tries to parse a document as js and the content contains a string with double quotes inside.
* Fix typescript headers type
* Fix FaunaHTTPError typo on types


[Jira Ticket](https://faunadb.atlassian.net/browse/FE-323)

### How to test
* Using typescript, try to pass the headers params as config and check if there is any error. You can use `{ headers: { 'X-Fauna-Source': 'VSCode' }}`
* Create a collection like `{ data: '<p style=""></p>' }` and stringify it using `Expr.toString()` and see if there is any parser error.

