### PR TITLE
Define constructor arguments of the RequestResult type as readonly properties

### DIFF
--- a/src/types/RequestResult.d.ts
+++ b/src/types/RequestResult.d.ts
@@ -1,5 +1,3 @@
-import Client from './Client'
-
 export default class RequestResult {
   constructor(
     method: string,
@@ -15,5 +13,16 @@ export default class RequestResult {
     endTime: Date
   )
 
-  timeTaken: number
+  readonly method: string
+  readonly path: string
+  readonly query: object
+  readonly requestRaw: string
+  readonly requestContent: object
+  readonly responseRaw: string
+  readonly responseContent: object
+  readonly statusCode: number
+  readonly responseHeaders: object
+  readonly startTime: Date
+  readonly endTime: Date
+  readonly timeTaken: number
 }


### PR DESCRIPTION
Fixes the `RequestResult` type to match the runtime.