### PR TITLE
feat: improved fql typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,3 +10,4 @@ export * from './src/types/values';
 export * from './src/types/PageHelper';
 export * from './src/types/query';
 export * from './src/types/RequestResult';
+export * from './src/types/json';

--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -1,4 +1,4 @@
-import Expr from './Expr'
+import Expr, { Materialize } from './Expr'
 import { ExprArg } from './query'
 import PageHelper from './PageHelper'
 import RequestResult from './RequestResult'
@@ -21,7 +21,7 @@ export interface QueryOptions {
 
 export default class Client {
   constructor(opts?: ClientConfig)
-  query<T = object>(expr: ExprArg, options?: QueryOptions): Promise<T>
+  query<T>(expr: ExprArg<T>, options?: QueryOptions): Promise<Materialize<T>>
   paginate(expr: Expr, params?: object, options?: QueryOptions): PageHelper
   ping(scope?: string, timeout?: number): Promise<string>
 }

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -122,4 +122,12 @@ export namespace Expr {
 
   /** Expression type for the `lambda` argument of `q.Filter` */
   export type Filter<T> = ExprVal<Lambda<[T], boolean>>
+
+  /** The expression type that can be mapped with `q.Map` */
+  export type Mappable<T = any> = Exclude<Iterable<T>, SetRef>
+
+  /** The expression type returned by `q.Map` */
+  export type MapResult<T extends Expr.Mappable, Out> = T extends Expr.Page
+    ? Expr.Page<Out>
+    : Expr<Out[]>
 }

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -58,12 +58,6 @@ export interface Document<T extends object> {
   ts: number
 }
 
-export interface Page<T> {
-  data: T[]
-  before?: string
-  after?: string
-}
-
 export interface Index<T extends object, Meta extends object = any> {
   ref: Expr.IndexRef<T, Meta>
   ts: number
@@ -112,6 +106,13 @@ export namespace Expr {
     extends Ref<Function<Return, Meta>> {}
 
   export interface Time extends Expr<values.FaunaTime> {}
+
+  export interface Page<T>
+    extends Expr<{
+      data: T[]
+      before?: string
+      after?: string
+    }> {}
 
   /** Expression types that can be passed to `q.Map`, `q.Filter`, etc */
   export type Iterable<T> = ExprVal<T[]> | ArrayRef<T> | Page<T>

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -88,11 +88,10 @@ export namespace Expr {
     private _refType: T
   }
 
-  /** @internal For type inference only. Please use `Expr.Iterable` instead. */
-  export interface ArrayRef<T = any> extends Ref<T[]> {}
-
-  /** Lazily evaluated set of refs */
-  export interface SetRef<T extends object = any> extends ArrayRef<Ref<T>> {}
+  export class SetRef<T = any> extends Expr<values.SetRef> {
+    // This prevents structural type equality.
+    private _type: 'SetRef' & T
+  }
 
   export interface DocumentRef<T extends object> extends Ref<Document<T>> {}
 
@@ -113,8 +112,8 @@ export namespace Expr {
     private _type: 'Page' & T
   }
 
-  /** Expression types that can be passed to `q.Map`, `q.Filter`, etc */
-  export type Iterable<T> = ExprVal<T[]> | ArrayRef<T> | Page<T>
+  /** The expression type for an iterable collection of values */
+  export type Iterable<T = any> = ExprVal<T[]> | SetRef<T> | Page<T>
 
   /** Expression type for the `path` argument of `q.Select` */
   export type KeyPath = ExprVal<(number | string)[]>

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -77,8 +77,8 @@ export interface Index<T extends object> {
   permissions?: object
 }
 
-export interface Function<T extends object> {
-  ref: Expr.FunctionRef<T>
+export interface Function<Return> {
+  ref: Expr.FunctionRef<Return>
   ts: number
   name: string
   body: object

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -104,35 +104,55 @@ export interface Function<Return, Meta extends object = any> {
 export namespace Expr {
   export class Ref<T = any> extends Expr<values.Ref> {
     // This prevents structural type equality.
-    private _type: 'Ref' & T
+    protected _type: 'Ref' & T
   }
 
   export class SetRef<T = any> extends Expr<values.SetRef> {
     // This prevents structural type equality.
-    private _type: 'SetRef' & T
+    protected _type: 'SetRef' & T
   }
 
-  export interface DocumentRef<T extends object> extends Ref<Document<T>> {}
+  export class DocumentRef<T extends object> extends Ref<Document<T>> {
+    // This prevents structural type equality.
+    protected _data: T
+  }
 
-  export interface CollectionRef<T extends object, Meta extends object = any>
-    extends Ref<Collection<T, Meta>> {}
+  export class CollectionRef<
+    T extends object,
+    Meta extends object = any
+  > extends Ref<Collection<T, Meta>> {
+    // This prevents structural type equality.
+    protected _data: T
+    protected _meta: Meta
+  }
 
-  export interface IndexRef<T extends object, Meta extends object = any>
-    extends Ref<Index<T, Meta>> {}
+  export class IndexRef<
+    T extends object,
+    Meta extends object = any
+  > extends Ref<Index<T, Meta>> {
+    // This prevents structural type equality.
+    protected _data: T
+    protected _meta: Meta
+  }
 
-  export interface FunctionRef<Return, Meta extends object = any>
-    extends Ref<Function<Return, Meta>> {}
+  export class FunctionRef<Return, Meta extends object = any> extends Ref<
+    Function<Return, Meta>
+  > {
+    // This prevents structural type equality.
+    protected _return: Return
+    protected _meta: Meta
+  }
 
   /** The expression type for a timestamp (nanosecond precision) */
   export class Time extends Expr<values.FaunaTime> {
     // This prevents structural type equality.
-    private _type: 'Time'
+    protected _type: 'Time'
   }
 
   /** The expression type for a page from a paginated set returned by `q.Paginate` */
   export class Page<T = any> extends Expr<values.Page<T>> {
     // This prevents structural type equality.
-    private _type: 'Page' & T
+    protected _type: 'Page' & T
   }
 
   /** The expression type for an iterable collection of values */

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -1,6 +1,103 @@
-export default class Expr {
+import { values } from './values'
+
+export default Expr
+
+export class Expr<T = any> {
   constructor(obj: object)
 
   readonly _isFaunaExpr?: boolean
   static toString(expr: Expr): string
+
+  // This prevents structural type equality with empty objects.
+  private _exprType: T
+}
+
+/** Materialize an `Expr` type into its result type. */
+export type Materialize<T> = T extends Expr<infer U>
+  ? U
+  : T extends ReadonlyArray<infer U>
+  ? (U[] extends T
+      ? ReadonlyArray<Materialize<U>>
+      : { [P in keyof T]: Materialize<T[P]> })
+  : T
+
+/** Add support for `Expr` types to any type. */
+export type ExprVal<T = unknown> =
+  | Expr<Exclude<T, Expr>>
+  | (T extends Expr | Lambda
+      ? T
+      : T extends ReadonlyArray<infer U>
+      ? (U[] extends T
+          ? ReadonlyArray<ExprVal<U>>
+          : { [P in keyof T]: ExprVal<T[P]> })
+      : T extends object
+      ? { [P in keyof T]: ExprVal<T[P]> }
+      : T)
+
+export type Lambda<In extends any[] = any[], Out = any> = (
+  ...args: In
+) => Expr<Out>
+
+export interface Collection<T> {
+  ref: Expr.CollectionRef<T>
+  ts: number
+  name: string
+  data?: object
+  permissions?: object
+  history_days: number | null
+  ttl_days?: number
+}
+
+export interface Document<T> {
+  data: T
+  ref: Expr.DocumentRef<T>
+  ts: number
+}
+
+export interface Page<T> {
+  data: T[]
+  before?: string
+  after?: string
+}
+
+export interface Index<T> {
+  ref: Expr.IndexRef<T>
+  ts: number
+  name: string
+  data?: object
+  source: Expr.CollectionRef<any> | any[]
+  partitions: number
+  active: boolean
+  serialized?: boolean
+  unique?: boolean
+  terms?: any[]
+  values?: any[]
+  permissions?: object
+}
+
+export interface Function<T> {
+  ref: Expr.FunctionRef<T>
+  ts: number
+  name: string
+  body: object
+  role?: any
+  data?: object
+}
+
+export namespace Expr {
+  export abstract class Ref<T> extends Expr<values.Ref> {
+    // This prevents structural type equality with empty objects.
+    private _refType: T
+  }
+
+  export interface DocumentRef<T> extends Ref<Document<T>> {}
+  export interface CollectionRef<T> extends Ref<Collection<T>> {}
+  export interface SetRef<T> extends Ref<Document<T>[]> {}
+  export interface IndexRef<T> extends Ref<Index<T>> {}
+  export interface FunctionRef<T> extends Ref<Function<T>> {}
+
+  export interface Time extends Expr<values.FaunaTime> {}
+
+  export type Iterable<T> = ExprVal<T[]> | SetRef<T> | Page<T>
+  export type KeyPath = ExprVal<(number | string)[]>
 }

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -102,9 +102,9 @@ export interface Function<Return, Meta extends object = any> {
 }
 
 export namespace Expr {
-  export abstract class Ref<T extends object = any> extends Expr<values.Ref> {
-    // This prevents structural type equality with empty objects.
-    private _refType: T
+  export class Ref<T = any> extends Expr<values.Ref> {
+    // This prevents structural type equality.
+    private _type: 'Ref' & T
   }
 
   export class SetRef<T = any> extends Expr<values.SetRef> {

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -85,7 +85,7 @@ export interface Function<T extends object> {
 }
 
 export namespace Expr {
-  export abstract class Ref<T> extends Expr<values.Ref> {
+  export abstract class Ref<T extends object = any> extends Expr<values.Ref> {
     // This prevents structural type equality with empty objects.
     private _refType: T
   }

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -107,12 +107,11 @@ export namespace Expr {
 
   export interface Time extends Expr<values.FaunaTime> {}
 
-  export interface Page<T>
-    extends Expr<{
-      data: T[]
-      before?: string
-      after?: string
-    }> {}
+  /** The expression type for a page from a paginated set returned by `q.Paginate` */
+  export class Page<T = any> extends Expr<values.Page<T>> {
+    // This prevents structural type equality.
+    private _type: 'Page' & T
+  }
 
   /** Expression types that can be passed to `q.Map`, `q.Filter`, etc */
   export type Iterable<T> = ExprVal<T[]> | ArrayRef<T> | Page<T>

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -59,7 +59,7 @@ export type ExprVal<T = unknown> =
 
 export type Lambda<In extends any[] = any[], Out = any> = (
   ...args: { [P in keyof In]: ToExpr<In[P]> }
-) => Expr<Out>
+) => ToExpr<Out>
 
 export interface Collection<T extends object, Meta extends object = any> {
   ref: Expr.CollectionRef<T, Meta>

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -90,7 +90,11 @@ export namespace Expr {
     private _refType: T
   }
 
-  export interface SetRef<T extends object = any> extends Ref<Ref<T>[]> {}
+  /** @internal For type inference only. Please use `Expr.Iterable` instead. */
+  export interface ArrayRef<T = any> extends Ref<T[]> {}
+
+  /** Lazily evaluated set of refs */
+  export interface SetRef<T extends object = any> extends ArrayRef<Ref<T>> {}
 
   export interface DocumentRef<T extends object> extends Ref<Document<T>> {}
 
@@ -102,7 +106,10 @@ export namespace Expr {
 
   export interface Time extends Expr<values.FaunaTime> {}
 
-  export type Iterable<T> = ExprVal<T[]> | SetRef<T> | Page<T>
+  /** Expression types that can be passed to `q.Map`, `q.Filter`, etc */
+  export type Iterable<T> = ExprVal<T[]> | ArrayRef<T> | Page<T>
+
+  /** Expression type for the `path` argument of `q.Select` */
   export type KeyPath = ExprVal<(number | string)[]>
 
   /** Expression type for the `lambda` argument of `q.Filter` */

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -40,11 +40,11 @@ export type Lambda<In extends any[] = any[], Out = any> = (
   ...args: { [P in keyof In]: ToExpr<In[P]> }
 ) => Expr<Out>
 
-export interface Collection<T extends object> {
-  ref: Expr.CollectionRef<T>
+export interface Collection<T extends object, Meta extends object = any> {
+  ref: Expr.CollectionRef<T, Meta>
   ts: number
   name: string
-  data?: object
+  data: Meta
   permissions?: object
   history_days: number | null
   ttl_days?: number
@@ -62,11 +62,11 @@ export interface Page<T> {
   after?: string
 }
 
-export interface Index<T extends object> {
-  ref: Expr.IndexRef<T>
+export interface Index<T extends object, Meta extends object = any> {
+  ref: Expr.IndexRef<T, Meta>
   ts: number
   name: string
-  data?: object
+  data: Meta
   source: Expr.CollectionRef<any> | any[]
   partitions: number
   active: boolean
@@ -77,13 +77,13 @@ export interface Index<T extends object> {
   permissions?: object
 }
 
-export interface Function<Return> {
-  ref: Expr.FunctionRef<Return>
+export interface Function<Return, Meta extends object = any> {
+  ref: Expr.FunctionRef<Return, Meta>
   ts: number
   name: string
+  data: Meta
   body: object
   role?: any
-  data?: object
 }
 
 export namespace Expr {
@@ -100,11 +100,14 @@ export namespace Expr {
 
   export interface DocumentRef<T extends object> extends Ref<Document<T>> {}
 
-  export interface CollectionRef<T extends object> extends Ref<Collection<T>> {}
+  export interface CollectionRef<T extends object, Meta extends object = any>
+    extends Ref<Collection<T, Meta>> {}
 
-  export interface IndexRef<T extends object> extends Ref<Index<T>> {}
+  export interface IndexRef<T extends object, Meta extends object = any>
+    extends Ref<Index<T, Meta>> {}
 
-  export interface FunctionRef<T> extends Ref<Function<T>> {}
+  export interface FunctionRef<Return, Meta extends object = any>
+    extends Ref<Function<Return, Meta>> {}
 
   export interface Time extends Expr<values.FaunaTime> {}
 

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -34,8 +34,10 @@ export type ExprVal<T = unknown> =
       ? { [P in keyof T]: ExprVal<T[P]> }
       : T)
 
+export type ToExpr<T> = T extends Expr ? T : Expr<T>
+
 export type Lambda<In extends any[] = any[], Out = any> = (
-  ...args: In
+  ...args: { [P in keyof In]: ToExpr<In[P]> }
 ) => Expr<Out>
 
 export interface Collection<T extends object> {

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -159,9 +159,7 @@ export namespace Expr {
   export type Iterable<T = any> = ExprVal<T[]> | SetRef<T> | Page<T>
 
   /** The expression type for a single value from an iterable */
-  export type IterableVal<T extends Iterable> = T extends SetRef<infer U>
-    ? Ref<U>
-    : T extends Iterable<infer U>
+  export type IterableVal<T extends Iterable> = T extends Iterable<infer U>
     ? ToExpr<U>
     : unknown
 

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -13,12 +13,12 @@ export class Expr<T = any> {
 }
 
 /** Materialize an `Expr` type into its result type. */
-export type Materialize<T> = T extends Expr<infer U>
+export type Materialize<T> = T extends ExprVal<Lambda>
+  ? never
+  : T extends Expr<infer U>
   ? U
-  : T extends ReadonlyArray<infer U>
-  ? (U[] extends T
-      ? ReadonlyArray<Materialize<U>>
-      : { [P in keyof T]: Materialize<T[P]> })
+  : T extends object
+  ? { [P in keyof T]: Materialize<T[P]> }
   : T
 
 /** Add support for `Expr` types to any type. */

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -23,7 +23,7 @@ export type Materialize<T> = T extends Expr<infer U>
 
 /** Add support for `Expr` types to any type. */
 export type ExprVal<T = unknown> =
-  | Expr<Exclude<T, Expr>>
+  | ToExpr<T>
   | (T extends Expr | Lambda
       ? T
       : T extends ReadonlyArray<infer U>

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -145,9 +145,10 @@ export namespace Expr {
     ? ToExpr<U>
     : unknown
 
+  /** The expression type for the `path` argument of `q.Select` */
   export type KeyPath = ExprVal<(number | string)[]>
 
-  /** Expression type for the `lambda` argument of `q.Filter` */
+  /** The expression type for the `lambda` argument of `q.Filter` */
   export type Filter<T> = ExprVal<Lambda<[T], boolean>>
 
   /** The expression type that can be mapped with `q.Map` */

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -38,7 +38,7 @@ export type Lambda<In extends any[] = any[], Out = any> = (
   ...args: In
 ) => Expr<Out>
 
-export interface Collection<T> {
+export interface Collection<T extends object> {
   ref: Expr.CollectionRef<T>
   ts: number
   name: string
@@ -48,7 +48,7 @@ export interface Collection<T> {
   ttl_days?: number
 }
 
-export interface Document<T> {
+export interface Document<T extends object> {
   data: T
   ref: Expr.DocumentRef<T>
   ts: number
@@ -60,7 +60,7 @@ export interface Page<T> {
   after?: string
 }
 
-export interface Index<T> {
+export interface Index<T extends object> {
   ref: Expr.IndexRef<T>
   ts: number
   name: string
@@ -75,7 +75,7 @@ export interface Index<T> {
   permissions?: object
 }
 
-export interface Function<T> {
+export interface Function<T extends object> {
   ref: Expr.FunctionRef<T>
   ts: number
   name: string
@@ -90,10 +90,14 @@ export namespace Expr {
     private _refType: T
   }
 
-  export interface DocumentRef<T> extends Ref<Document<T>> {}
-  export interface CollectionRef<T> extends Ref<Collection<T>> {}
-  export interface SetRef<T> extends Ref<Document<T>[]> {}
-  export interface IndexRef<T> extends Ref<Index<T>> {}
+  export interface DocumentRef<T extends object> extends Ref<Document<T>> {}
+
+  export interface SetRef<T extends object> extends Ref<Document<T>[]> {}
+
+  export interface CollectionRef<T extends object> extends Ref<Collection<T>> {}
+
+  export interface IndexRef<T extends object> extends Ref<Index<T>> {}
+
   export interface FunctionRef<T> extends Ref<Function<T>> {}
 
   export interface Time extends Expr<values.FaunaTime> {}

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -20,7 +20,7 @@ export type Materialize<T> = T extends ExprVal<Lambda>
   ? T
   : T extends Expr<infer U>
   ? { [P in keyof U]: Materialize<U> }[keyof U]
-  : T extends JsonObject
+  : T extends object
   ? { [P in keyof T]: Materialize<T[P]> }
   : T
 
@@ -33,7 +33,7 @@ type Eval<T> = T extends Expr<infer U>
   ? (Expr extends T ? U : never)
   : T extends Lambda
   ? T
-  : T extends JsonObject
+  : T extends object
   ? { [P in keyof T]: Eval<T[P]> | NominalExpr<T[P]> }
   : T
 
@@ -56,7 +56,7 @@ export type ExprVal<T = unknown> =
       ? never
       : T extends Lambda
       ? T
-      : T extends JsonObject
+      : T extends object
       ? { [P in keyof T]: ExprVal<T[P]> }
       : T)
 

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -104,4 +104,7 @@ export namespace Expr {
 
   export type Iterable<T> = ExprVal<T[]> | SetRef<T> | Page<T>
   export type KeyPath = ExprVal<(number | string)[]>
+
+  /** Expression type for the `lambda` argument of `q.Filter` */
+  export type Filter<T> = ExprVal<Lambda<[T], boolean>>
 }

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -166,7 +166,7 @@ export namespace Expr {
     : unknown
 
   /** The expression type for the `path` argument of `q.Select` */
-  export type KeyPath = ExprVal<(number | string)[]>
+  export type KeyPath = ExprVal<string | number | (number | string)[]>
 
   /** The expression type for the `lambda` argument of `q.Filter` */
   export type Filter<T> = ExprVal<Lambda<[T], boolean>>

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -90,9 +90,9 @@ export namespace Expr {
     private _refType: T
   }
 
-  export interface DocumentRef<T extends object> extends Ref<Document<T>> {}
+  export interface SetRef<T extends object = any> extends Ref<Ref<T>[]> {}
 
-  export interface SetRef<T extends object> extends Ref<Document<T>[]> {}
+  export interface DocumentRef<T extends object> extends Ref<Document<T>> {}
 
   export interface CollectionRef<T extends object> extends Ref<Collection<T>> {}
 

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -47,7 +47,7 @@ export type ToExpr<T> =
   // Preserve nominal subtypes of `Expr`
   | NominalExpr<T>
   // Merge plain `Expr` types with primitive types
-  | (Eval<T> extends infer U ? ([U] extends [never] ? never : Expr<U>) : never)
+  | (Eval<T> extends infer U ? ([U] extends [void] ? never : Expr<U>) : never)
 
 /** Add support for `Expr` types to any type. */
 export type ExprVal<T = unknown> =

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -1,9 +1,10 @@
+import { JsonObject } from './json'
 import { values } from './values'
 
 export default Expr
 
 export class Expr<T = any> {
-  constructor(obj: object)
+  constructor(obj: JsonObject)
 
   readonly _isFaunaExpr?: boolean
   static toString(expr: Expr): string
@@ -17,7 +18,7 @@ export type Materialize<T> = T extends ExprVal<Lambda>
   ? never
   : T extends Expr<infer U>
   ? U
-  : T extends object
+  : T extends JsonObject
   ? { [P in keyof T]: Materialize<T[P]> }
   : T
 
@@ -30,7 +31,7 @@ type Eval<T> = T extends Expr<infer U>
   ? (Expr extends T ? U : never)
   : T extends Lambda
   ? T
-  : T extends object
+  : T extends JsonObject
   ? { [P in keyof T]: Eval<T[P]> | NominalExpr<T[P]> }
   : T
 
@@ -53,7 +54,7 @@ export type ExprVal<T = unknown> =
       ? never
       : T extends Lambda
       ? T
-      : T extends object
+      : T extends JsonObject
       ? { [P in keyof T]: ExprVal<T[P]> }
       : T)
 
@@ -61,23 +62,26 @@ export type Lambda<In extends any[] = any[], Out = any> = (
   ...args: { [P in keyof In]: ToExpr<In[P]> }
 ) => ToExpr<Out>
 
-export interface Collection<T extends object, Meta extends object = any> {
+export interface Collection<
+  T extends JsonObject,
+  Meta extends JsonObject = any
+> {
   ref: Expr.CollectionRef<T, Meta>
   ts: number
   name: string
   data: Meta
-  permissions?: object
+  permissions?: JsonObject
   history_days: number | null
   ttl_days?: number
 }
 
-export interface Document<T extends object> {
+export interface Document<T extends JsonObject> {
   data: T
   ref: Expr.DocumentRef<T>
   ts: number
 }
 
-export interface Index<T extends object, Meta extends object = any> {
+export interface Index<T extends JsonObject, Meta extends JsonObject = any> {
   ref: Expr.IndexRef<T, Meta>
   ts: number
   name: string
@@ -89,15 +93,15 @@ export interface Index<T extends object, Meta extends object = any> {
   unique?: boolean
   terms?: any[]
   values?: any[]
-  permissions?: object
+  permissions?: JsonObject
 }
 
-export interface Function<Return, Meta extends object = any> {
+export interface Function<Return, Meta extends JsonObject = any> {
   ref: Expr.FunctionRef<Return, Meta>
   ts: number
   name: string
   data: Meta
-  body: object
+  body: JsonObject
   role?: any
 }
 
@@ -112,14 +116,14 @@ export namespace Expr {
     protected _type: 'SetRef' & T
   }
 
-  export class DocumentRef<T extends object> extends Ref<Document<T>> {
+  export class DocumentRef<T extends JsonObject> extends Ref<Document<T>> {
     // This prevents structural type equality.
     protected _data: T
   }
 
   export class CollectionRef<
-    T extends object,
-    Meta extends object = any
+    T extends JsonObject,
+    Meta extends JsonObject = any
   > extends Ref<Collection<T, Meta>> {
     // This prevents structural type equality.
     protected _data: T
@@ -127,15 +131,15 @@ export namespace Expr {
   }
 
   export class IndexRef<
-    T extends object,
-    Meta extends object = any
+    T extends JsonObject,
+    Meta extends JsonObject = any
   > extends Ref<Index<T, Meta>> {
     // This prevents structural type equality.
     protected _data: T
     protected _meta: Meta
   }
 
-  export class FunctionRef<Return, Meta extends object = any> extends Ref<
+  export class FunctionRef<Return, Meta extends JsonObject = any> extends Ref<
     Function<Return, Meta>
   > {
     // This prevents structural type equality.

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -138,7 +138,13 @@ export namespace Expr {
   /** The expression type for an iterable collection of values */
   export type Iterable<T = any> = ExprVal<T[]> | SetRef<T> | Page<T>
 
-  /** Expression type for the `path` argument of `q.Select` */
+  /** The expression type for a single value from an iterable */
+  export type IterableVal<T extends Iterable> = T extends SetRef<infer U>
+    ? Ref<U>
+    : T extends Iterable<infer U>
+    ? ToExpr<U>
+    : unknown
+
   export type KeyPath = ExprVal<(number | string)[]>
 
   /** Expression type for the `lambda` argument of `q.Filter` */

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -123,7 +123,11 @@ export namespace Expr {
   export interface FunctionRef<Return, Meta extends object = any>
     extends Ref<Function<Return, Meta>> {}
 
-  export interface Time extends Expr<values.FaunaTime> {}
+  /** The expression type for a timestamp (nanosecond precision) */
+  export class Time extends Expr<values.FaunaTime> {
+    // This prevents structural type equality.
+    private _type: 'Time'
+  }
 
   /** The expression type for a page from a paginated set returned by `q.Paginate` */
   export class Page<T = any> extends Expr<values.Page<T>> {

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -49,12 +49,10 @@ export type ToExpr<T> =
 /** Add support for `Expr` types to any type. */
 export type ExprVal<T = unknown> =
   | ToExpr<T>
-  | (T extends Expr | Lambda
+  | (T extends Expr
+      ? never
+      : T extends Lambda
       ? T
-      : T extends ReadonlyArray<infer U>
-      ? (U[] extends T
-          ? ReadonlyArray<ExprVal<U>>
-          : { [P in keyof T]: ExprVal<T[P]> })
       : T extends object
       ? { [P in keyof T]: ExprVal<T[P]> }
       : T)

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -34,7 +34,9 @@ export type ExprVal<T = unknown> =
       ? { [P in keyof T]: ExprVal<T[P]> }
       : T)
 
-export type ToExpr<T> = T extends Expr ? T : Expr<T>
+export type ToExpr<T> = [T] extends [infer U]
+  ? (T extends Expr ? T : Expr<Exclude<U, Expr>>)
+  : never
 
 export type Lambda<In extends any[] = any[], Out = any> = (
   ...args: { [P in keyof In]: ToExpr<In[P]> }

--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -1,5 +1,5 @@
+import { values, Page as PageData, SetRef, Ref } from './values'
 import { JsonObject } from './json'
-import { values } from './values'
 
 export default Expr
 
@@ -9,23 +9,25 @@ export class Expr<T = any> {
   readonly _isFaunaExpr?: boolean
   static toString(expr: Expr): string
 
-  // This prevents structural type equality with empty objects.
-  private _exprType: T
+  /** This enforces type nominality. */
+  private _type: T
 }
 
 /** Materialize an `Expr` type into its result type. */
 export type Materialize<T> = T extends ExprVal<Lambda>
   ? never
+  : T extends Ref | SetRef
+  ? T
   : T extends Expr<infer U>
-  ? U
+  ? { [P in keyof U]: Materialize<U> }[keyof U]
   : T extends JsonObject
   ? { [P in keyof T]: Materialize<T[P]> }
   : T
 
 /**
  * Evaluate the given type as an expression. Since nominal subtypes
- * of `Expr` (like `Expr.Ref`) are handled by `ToExpr`, they are
- * omitted. Use `Materialize` if you need them too.
+ * of `Expr` (like `Ref`) are handled by `ToExpr`, they are omitted.
+ * Use `Materialize` if you need them too.
  */
 type Eval<T> = T extends Expr<infer U>
   ? (Expr extends T ? U : never)
@@ -62,102 +64,12 @@ export type Lambda<In extends any[] = any[], Out = any> = (
   ...args: { [P in keyof In]: ToExpr<In[P]> }
 ) => ToExpr<Out>
 
-export interface Collection<
-  T extends JsonObject,
-  Meta extends JsonObject = any
-> {
-  ref: Expr.CollectionRef<T, Meta>
-  ts: number
-  name: string
-  data: Meta
-  permissions?: JsonObject
-  history_days: number | null
-  ttl_days?: number
-}
-
-export interface Document<T extends JsonObject> {
-  data: T
-  ref: Expr.DocumentRef<T>
-  ts: number
-}
-
-export interface Index<T extends JsonObject, Meta extends JsonObject = any> {
-  ref: Expr.IndexRef<T, Meta>
-  ts: number
-  name: string
-  data: Meta
-  source: Expr.CollectionRef<any> | any[]
-  partitions: number
-  active: boolean
-  serialized?: boolean
-  unique?: boolean
-  terms?: any[]
-  values?: any[]
-  permissions?: JsonObject
-}
-
-export interface Function<Return, Meta extends JsonObject = any> {
-  ref: Expr.FunctionRef<Return, Meta>
-  ts: number
-  name: string
-  data: Meta
-  body: JsonObject
-  role?: any
-}
-
 export namespace Expr {
-  export class Ref<T = any> extends Expr<values.Ref> {
-    // This prevents structural type equality.
-    protected _type: 'Ref' & T
-  }
-
-  export class SetRef<T = any> extends Expr<values.SetRef> {
-    // This prevents structural type equality.
-    protected _type: 'SetRef' & T
-  }
-
-  export class DocumentRef<T extends JsonObject> extends Ref<Document<T>> {
-    // This prevents structural type equality.
-    protected _data: T
-  }
-
-  export class CollectionRef<
-    T extends JsonObject,
-    Meta extends JsonObject = any
-  > extends Ref<Collection<T, Meta>> {
-    // This prevents structural type equality.
-    protected _data: T
-    protected _meta: Meta
-  }
-
-  export class IndexRef<
-    T extends JsonObject,
-    Meta extends JsonObject = any
-  > extends Ref<Index<T, Meta>> {
-    // This prevents structural type equality.
-    protected _data: T
-    protected _meta: Meta
-  }
-
-  export class FunctionRef<Return, Meta extends JsonObject = any> extends Ref<
-    Function<Return, Meta>
-  > {
-    // This prevents structural type equality.
-    protected _return: Return
-    protected _meta: Meta
-  }
-
   /** The expression type for a timestamp (nanosecond precision) */
-  export class Time extends Expr<values.FaunaTime> {
-    // This prevents structural type equality.
-    protected _type: 'Time'
-  }
+  export class Time extends Expr<values.FaunaTime> {}
 
   /** The expression type for a page from a paginated set returned by `q.Paginate` */
-  export class Page<T = any> extends Expr<values.Page<T>> {
-    // This prevents structural type equality.
-    protected _type: 'Page' & T
-  }
+  export class Page<T = any> extends Expr<PageData<T>> {}
 
   /** The expression type for an iterable collection of values */
   export type Iterable<T = any> = ExprVal<T[]> | SetRef<T> | Page<T>
@@ -177,7 +89,7 @@ export namespace Expr {
   export type Mappable<T = any> = Exclude<Iterable<T>, SetRef>
 
   /** The expression type returned by `q.Map` */
-  export type MapResult<T extends Expr.Mappable, Out> = T extends Expr.Page
-    ? Expr.Page<Out>
+  export type MapResult<T extends Mappable, Out> = T extends Page
+    ? Page<Out>
     : Expr<Out[]>
 }

--- a/src/types/PageHelper.d.ts
+++ b/src/types/PageHelper.d.ts
@@ -1,6 +1,5 @@
 import Client, { QueryOptions } from './Client'
-import Expr from './Expr'
-import { Lambda } from './query'
+import Expr, { Lambda } from './Expr'
 
 export default class PageHelper {
   constructor(

--- a/src/types/json.d.ts
+++ b/src/types/json.d.ts
@@ -1,4 +1,13 @@
-export type Json = string | number | boolean | null | JsonObject | JsonArray
+import { values } from './values'
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonObject
+  | JsonArray
+  | values.Value
 
 export interface JsonObject {
   [property: string]: Json

--- a/src/types/json.d.ts
+++ b/src/types/json.d.ts
@@ -1,0 +1,7 @@
+export type Json = string | number | boolean | null | JsonObject | JsonArray
+
+export interface JsonObject {
+  [property: string]: Json
+}
+
+export interface JsonArray extends ReadonlyArray<Json> {}

--- a/src/types/json.d.ts
+++ b/src/types/json.d.ts
@@ -10,7 +10,7 @@ export type Json =
   | values.Value
 
 export interface JsonObject {
-  [property: string]: Json
+  readonly [property: string]: Json | undefined
 }
 
 export interface JsonArray extends ReadonlyArray<Json> {}

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -86,17 +86,17 @@ export module query {
   // TODO
   export function Var(varName: ExprArg): Expr
 
-  export function If<T>(
-    condition: ExprArg<boolean>,
-    then: ExprArg<T>,
-    _else: ExprArg<T>
-  ): Expr<T>
-
   export function If<T, U>(
-    condition: ExprArg<boolean>,
-    then: ExprArg<T>,
-    _else: ExprArg<U>
+    condition: ExprVal<boolean>,
+    then: ExprVal<T>,
+    _else: ExprVal<U>
   ): Expr<T | U>
+
+  export function If<T>(
+    condition: ExprVal<boolean>,
+    then: ExprVal<T>,
+    _else: ExprVal<T>
+  ): Expr<T>
 
   // TODO
   export function Do(...args: ExprArg[]): Expr

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -194,9 +194,9 @@ export module query {
   export function IsRole(expr: ExprArg): Expr
 
   export function Get<T extends object>(
-    ref: Expr.Ref<T>,
+    ref: Expr.Ref<T> | Expr.SetRef<T>,
     ts?: ExprVal<number | Expr.Time>
-  ): Expr<T extends (infer U)[] ? U : T>
+  ): Expr<T>
 
   // TODO
   export function KeyFromSecret(secret: ExprArg): Expr

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -117,7 +117,7 @@ export module query {
   export function Filter<T>(
     collection: Expr.Iterable<T>,
     lambda_expr: ExprVal<Lambda<[T], boolean>>
-  ): Expr<T>
+  ): Expr<T[]>
 
   // TODO
   export function Take(number: ExprArg, collection: ExprArg): Expr

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -6,6 +6,7 @@ import Expr, {
   Page,
   Index,
   Function,
+  ToExpr,
 } from './Expr'
 
 export type ExprArg<T = unknown> = ExprVal<T> | Array<ExprVal<T>>
@@ -393,7 +394,7 @@ export module query {
     path: Expr.KeyPath,
     from: Expr<object>,
     _default?: ExprVal<T>
-  ): Expr<Exclude<T, Expr>>
+  ): ToExpr<T>
 
   // TODO
   export function SelectAll(path: ExprArg, from: ExprArg): Expr

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -171,7 +171,7 @@ export module query {
   export function Paginate<T>(
     set: Expr.SetRef<T>,
     params?: ExprVal<PaginateParams>
-  ): Page<T>
+  ): Page<Expr.Ref<T>>
 
   export function Exists(
     ref: Expr.Ref<any>,

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -410,9 +410,9 @@ export module query {
   export function ContainsField(field: string, _in: ExprArg): Expr
   export function ContainsValue(value: ExprArg, _in: ExprArg): Expr
 
-  export function Select<T>(
-    path: Expr.KeyPath,
-    from: Expr<object>,
+  export function Select<T = any>(
+    path: ExprVal<string | number> | Expr.KeyPath,
+    from: ExprVal<object>,
     _default?: ExprVal<T>
   ): ToExpr<T>
 

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -109,10 +109,11 @@ export module query {
     values: ExprArg,
     resolver?: Expr | Lambda
   ): Expr
-  export function Foreach(
-    collection: ExprArg,
-    lambda_expr: ExprArg | Lambda
-  ): Expr
+
+  export function Foreach<T, U extends Expr.Iterable<T>>(
+    collection: U,
+    lambda_expr: ExprVal<Lambda<[T]>>
+  ): U
 
   export function Filter<T>(
     collection: Expr.Iterable<T>,

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -137,7 +137,7 @@ export module query {
     expr: ExprArg<Out>
   ): Expr<Lambda<In, Out>>
 
-  export function Call<T>(ref: FunctionRef<T>, ...args: any[]): Expr<T>
+  export function Call<T>(ref: string | FunctionRef<T>, ...args: any[]): Expr<T>
 
   // TODO
   export function Query(lambda: ExprArg | Lambda): Expr

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -194,7 +194,7 @@ export module query {
   export function IsRole(expr: ExprArg): Expr
 
   export function Get<T extends object>(
-    ref: Expr.Ref<T> | Expr.SetRef<T>,
+    ref: Expr.Ref<T> | Expr.SetRef<Expr.Ref<T>>,
     ts?: ExprVal<number | Expr.Time>
   ): Expr<T>
 
@@ -209,7 +209,7 @@ export module query {
   export function Paginate<T extends object>(
     set: Expr.SetRef<T>,
     params?: ExprVal<PaginateParams>
-  ): Expr.Page<Expr.Ref<T>>
+  ): Expr.Page<T>
 
   export function Exists(
     ref: Expr.Ref<any>,
@@ -277,7 +277,7 @@ export module query {
   export function Match<T extends object>(
     index: Expr.IndexRef<T>,
     ...terms: any[]
-  ): Expr.SetRef<Document<T>>
+  ): Expr.SetRef<Expr.DocumentRef<T>>
 
   // TODO
   export function Union(...sets: ExprArg[]): Expr
@@ -389,13 +389,15 @@ export module query {
   export function Databases(scope?: ExprArg): Expr
 
   // TODO: "scope" argument
-  export function Collections(scope?: ExprArg): Expr.SetRef<Collection<any>>
+  export function Collections(
+    scope?: ExprArg
+  ): Expr.SetRef<Expr.CollectionRef<any>>
 
   // TODO: "scope" argument
-  export function Indexes(scope?: ExprArg): Expr.SetRef<Index<any>>
+  export function Indexes(scope?: ExprArg): Expr.SetRef<Expr.IndexRef<any>>
 
   // TODO: "scope" argument
-  export function Functions(scope?: ExprArg): Expr.SetRef<Function<any>>
+  export function Functions(scope?: ExprArg): Expr.SetRef<Expr.FunctionRef<any>>
 
   // TODO
   export function Roles(scope?: ExprArg): Expr
@@ -491,5 +493,5 @@ export module query {
 
   export function Documents<T extends object>(
     collection: Expr.CollectionRef<T>
-  ): Expr.SetRef<Document<T>>
+  ): Expr.SetRef<Expr.DocumentRef<T>>
 }

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -148,9 +148,9 @@ export module query {
     resolver?: Expr | Lambda
   ): Expr
 
-  export function Foreach<T extends Expr.Iterable<any>>(
+  export function Foreach<T extends Expr.Iterable>(
     collection: T,
-    lambda_expr: T extends Expr.Iterable<infer U> ? ExprVal<Lambda<[U]>> : never
+    lambda_expr: ExprVal<Lambda<[Expr.IterableVal<T>]>>
   ): T
 
   export function Filter<T>(

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -116,7 +116,7 @@ export module query {
 
   export function Filter<T>(
     collection: Expr.Iterable<T>,
-    lambda_expr: ExprVal<Lambda<[T], boolean>>
+    lambda_expr: Expr.Filter<T>
   ): Expr<T[]>
 
   // TODO

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -165,7 +165,7 @@ export module query {
   export function Append(elements: ExprArg, collection: ExprArg): Expr
   export function Reverse(expr: ExprArg): Expr
 
-  export function IsEmpty(collection: Expr.Iterable<any>): Expr<boolean>
+  export function IsEmpty(collection: Expr.Iterable): Expr<boolean>
 
   // TODO
   export function IsNonEmpty(collection: ExprArg): Expr

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -3,7 +3,6 @@ import Expr, {
   Lambda,
   Document,
   Collection,
-  Page,
   Index,
   Function,
   ToExpr,
@@ -189,7 +188,7 @@ export module query {
   export function Paginate<T extends object>(
     set: Expr.SetRef<T>,
     params?: ExprVal<PaginateParams>
-  ): Page<Expr.Ref<T>>
+  ): Expr.Page<Expr.Ref<T>>
 
   export function Exists(
     ref: Expr.Ref<any>,

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -219,7 +219,7 @@ export module query {
   export function Create<T extends object>(
     collection_ref: Expr.CollectionRef<T>,
     params: ExprVal<CreateParams<T>>
-  ): Document<T>
+  ): Expr<Document<T>>
 
   export function Update<T extends Updatable>(
     ref: T,

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -128,10 +128,10 @@ export module query {
     resolver?: Expr | Lambda
   ): Expr
 
-  export function Foreach<T, U extends Expr.Iterable<T>>(
-    collection: U,
-    lambda_expr: ExprVal<Lambda<[T]>>
-  ): U
+  export function Foreach<T extends Expr.Iterable<any>>(
+    collection: T,
+    lambda_expr: T extends Expr.Iterable<infer U> ? ExprVal<Lambda<[U]>> : never
+  ): T
 
   export function Filter<T>(
     collection: Expr.Iterable<T>,

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -100,7 +100,7 @@ export module query {
 
   export function Map<T, Out>(
     collection: Expr.Iterable<T>,
-    lambda_expr: ExprVal<Lambda<[T extends Expr ? T : Expr<T>], Out>>
+    lambda_expr: ExprVal<Lambda<[T], Out>>
   ): Expr<Out[]>
 
   // TODO

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -17,15 +17,15 @@ export type CreateParams<T extends object> = ExprVal<{
   ttl?: Expr.Time
 }>
 
-export type CreateCollectionParams = {
+export type CreateCollectionParams<Meta extends object = any> = {
   name: string
-  data?: object
+  data?: Meta
   permissions?: object
   history_days?: number
   ttl_days?: number
 }
 
-export type CreateIndexParams = {
+export type CreateIndexParams<Meta extends object = any> = {
   name: string
   source: Expr.CollectionRef<any> | any[]
   terms?: any[]
@@ -33,7 +33,7 @@ export type CreateIndexParams = {
   unique?: boolean
   serialized?: boolean
   permissions?: object
-  data?: object
+  data?: Meta
 }
 
 export type PaginateParams = {
@@ -45,10 +45,10 @@ export type PaginateParams = {
   sources?: boolean
 }
 
-export type FunctionParams = {
+export type FunctionParams<Meta extends object = any> = {
   name: string
   body: object
-  data?: object
+  data?: Meta
   role?: any
 }
 
@@ -206,23 +206,23 @@ export module query {
   export function Remove(ref: ExprArg, ts: ExprArg, action: ExprArg): Expr
   export function CreateClass(params: ExprArg): Expr
 
-  export function CreateCollection<T extends object>(
-    params: ExprVal<CreateCollectionParams>
-  ): Expr<Collection<T>>
+  export function CreateCollection<T extends object, Meta extends object = any>(
+    params: ExprVal<CreateCollectionParams<Meta>>
+  ): Expr<Collection<T, Meta>>
 
   // TODO
   export function CreateDatabase(params: ExprArg): Expr
 
-  export function CreateIndex<T extends object>(
-    params: ExprVal<CreateIndexParams>
-  ): Expr<Index<T>>
+  export function CreateIndex<T extends object, Meta extends object = any>(
+    params: ExprVal<CreateIndexParams<Meta>>
+  ): Expr<Index<T, Meta>>
 
   // TODO
   export function CreateKey(params: ExprArg): Expr
 
-  export function CreateFunction<T>(
-    params: ExprVal<FunctionParams>
-  ): Expr<Function<T>>
+  export function CreateFunction<Return, Meta extends object = any>(
+    params: ExprVal<FunctionParams<Meta>>
+  ): Expr<Function<Return>>
 
   // TODO
   export function CreateRole(params: ExprArg): Expr
@@ -323,22 +323,22 @@ export module query {
   export function Database(name: ExprArg, scope?: ExprArg): Expr
 
   // TODO: "scope" argument
-  export function Index<T extends object>(
+  export function Index<T extends object, Meta extends object = any>(
     name: ExprVal<string>,
     scope?: ExprArg
-  ): Expr.IndexRef<T>
+  ): Expr.IndexRef<T, Meta>
 
   // TODO: "scope" argument
-  export function Collection<T extends object>(
+  export function Collection<T extends object, Meta extends object = any>(
     name: ExprVal<string>,
     scope?: ExprArg
-  ): Expr.CollectionRef<T>
+  ): Expr.CollectionRef<T, Meta>
 
   // TODO: "scope" argument
-  export function Function<T>(
+  export function Function<Return, Meta extends object = any>(
     name: ExprVal<string>,
     scope?: ExprArg
-  ): Expr.FunctionRef<T>
+  ): Expr.FunctionRef<Return, Meta>
 
   // TODO
   export function Role(name: ExprArg, scope?: ExprArg): Expr

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -17,6 +17,23 @@ export type CreateParams<T extends object> = ExprVal<{
   ttl?: Expr.Time
 }>
 
+type Updatable<T extends object = any> =
+  | Expr.DocumentRef<T>
+  | Expr.CollectionRef<any, T>
+  | Expr.IndexRef<any, T>
+  | Expr.FunctionRef<any, T>
+
+export type UpdateParams<T extends Updatable> = unknown &
+  T extends Expr.DocumentRef<infer U>
+  ? {
+      data?: Partial<U>
+      credentials?: object
+      delegates?: object
+    }
+  : T extends Expr.Ref<infer U>
+  ? Omit<Partial<U>, 'ref' | 'ts'>
+  : never
+
 export type CreateCollectionParams<Meta extends object = any> = {
   name: string
   data?: Meta
@@ -183,8 +200,12 @@ export module query {
     params: ExprVal<CreateParams<T>>
   ): Document<T>
 
+  export function Update<T extends Updatable>(
+    ref: T,
+    params: ExprVal<UpdateParams<T>>
+  ): Expr<T extends Expr.Ref<infer U> ? U : never>
+
   // TODO
-  export function Update(ref: ExprArg, params: ExprArg): Expr
   export function Replace(ref: ExprArg, params: ExprArg): Expr
 
   export function Delete(

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -50,7 +50,7 @@ export type CreateCollectionParams<Meta extends JsonObject = any> = {
 
 export type CreateIndexParams<Meta extends JsonObject = any> = {
   name: string
-  source: CollectionRef<any> | any[]
+  source: CollectionRef | any[]
   terms?: any[]
   values?: any[]
   unique?: boolean
@@ -217,7 +217,7 @@ export module query {
     params?: ExprVal<PaginateParams>
   ): Expr.Page<T>
 
-  export function Exists(ref: Ref<any>, ts?: ExprVal<number>): Expr<boolean>
+  export function Exists(ref: Ref, ts?: ExprVal<number>): Expr<boolean>
 
   export function Create<T extends JsonObject>(
     collection_ref: CollectionRef<T>,
@@ -233,7 +233,7 @@ export module query {
   export function Replace(ref: ExprArg, params: ExprArg): Expr
 
   export function Delete(
-    ref: Ref<any>
+    ref: Ref
   ): Expr<{
     database: string
     role: string
@@ -394,13 +394,13 @@ export module query {
   export function Databases(scope?: ExprArg): Expr
 
   // TODO: "scope" argument
-  export function Collections(scope?: ExprArg): SetRef<CollectionRef<any>>
+  export function Collections(scope?: ExprArg): SetRef<CollectionRef>
 
   // TODO: "scope" argument
-  export function Indexes(scope?: ExprArg): SetRef<IndexRef<any>>
+  export function Indexes(scope?: ExprArg): SetRef<IndexRef>
 
   // TODO: "scope" argument
-  export function Functions(scope?: ExprArg): SetRef<FunctionRef<any>>
+  export function Functions(scope?: ExprArg): SetRef<FunctionRef>
 
   // TODO
   export function Roles(scope?: ExprArg): Expr

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -376,7 +376,10 @@ export module query {
   // TODO
   export function SelectAll(path: ExprArg, from: ExprArg): Expr
   export function Abs(expr: ExprArg): Expr
-  export function Add(...args: ExprArg[]): Expr
+
+  export function Add(...args: ExprVal<number>[]): Expr<number>
+
+  // TODO
   export function BitAnd(...args: ExprArg[]): Expr
   export function BitNot(expr: ExprArg): Expr
   export function BitOr(...args: ExprArg[]): Expr

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -405,8 +405,12 @@ export module query {
 
   export function Equals(...args: any[]): Expr<boolean>
 
+  export function ContainsPath(
+    path: Expr.KeyPath,
+    _in: ExprVal<object>
+  ): Expr<boolean>
+
   // TODO
-  export function ContainsPath(path: ExprArg, _in: ExprArg): Expr
   export function ContainsField(field: string, _in: ExprArg): Expr
   export function ContainsValue(value: ExprArg, _in: ExprArg): Expr
 

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -117,7 +117,7 @@ export module query {
   export function Query(lambda: ExprArg | Lambda): Expr
 
   export function Map<T, Out>(
-    collection: Expr.Iterable<T>,
+    collection: Exclude<Expr.Iterable<T>, Expr.ArrayRef>,
     lambda_expr: ExprVal<Lambda<[T], Out>>
   ): Expr<Out[]>
 

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -10,6 +10,48 @@ import Expr, {
 
 export type ExprArg<T = unknown> = ExprVal<T> | Array<ExprVal<T>>
 
+export type CreateParams<T> = ExprVal<{
+  data: T
+  credentials?: object
+  delegates?: object
+  ttl?: Expr.Time
+}>
+
+export type CreateCollectionParams = {
+  name: string
+  data?: object
+  permissions?: object
+  history_days?: number
+  ttl_days?: number
+}
+
+export type CreateIndexParams = {
+  name: string
+  source: Expr.CollectionRef<any> | any[]
+  terms?: any[]
+  values?: any[]
+  unique?: boolean
+  serialized?: boolean
+  permissions?: object
+  data?: object
+}
+
+export type PaginateParams = {
+  ts?: number | Expr.Time
+  size?: number
+  before?: string
+  after?: string
+  events?: boolean
+  sources?: boolean
+}
+
+export type FunctionParams = {
+  name: string
+  body: object
+  data?: object
+  role?: any
+}
+
 export module query {
   export function Ref<T>(
     ref: Expr.CollectionRef<T>,
@@ -127,14 +169,7 @@ export module query {
 
   export function Paginate<T>(
     set: Expr.SetRef<T>,
-    params?: ExprVal<{
-      ts?: number | Expr.Time
-      size?: number
-      before?: string
-      after?: string
-      events?: boolean
-      sources?: boolean
-    }>
+    params?: ExprVal<PaginateParams>
   ): Page<T>
 
   // TODO
@@ -142,12 +177,7 @@ export module query {
 
   export function Create<T>(
     collection_ref: Expr.CollectionRef<T>,
-    params: ExprVal<{
-      data: T
-      credentials?: object
-      delegates?: object
-      ttl?: Expr.Time
-    }>
+    params: ExprVal<CreateParams<T>>
   ): Document<T>
 
   // TODO
@@ -174,41 +204,21 @@ export module query {
   export function CreateClass(params: ExprArg): Expr
 
   export function CreateCollection<T>(
-    params: ExprVal<{
-      name: string
-      data?: object
-      permissions?: object
-      history_days?: number
-      ttl_days?: number
-    }>
+    params: ExprVal<CreateCollectionParams>
   ): Expr<Collection<T>>
 
   // TODO
   export function CreateDatabase(params: ExprArg): Expr
 
   export function CreateIndex<T>(
-    params: ExprVal<{
-      name: string
-      source: Expr.CollectionRef<any> | any[]
-      terms?: any[]
-      values?: any[]
-      unique?: boolean
-      serialized?: boolean
-      permissions?: object
-      data?: object
-    }>
+    params: ExprVal<CreateIndexParams>
   ): Expr<Index<T>>
 
   // TODO
   export function CreateKey(params: ExprArg): Expr
 
   export function CreateFunction<T>(
-    params: ExprVal<{
-      name: string
-      body: object
-      data?: object
-      role?: any
-    }>
+    params: ExprVal<FunctionParams>
   ): Expr<Function<T>>
 
   // TODO

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -416,6 +416,11 @@ export module query {
   export function ContainsField(field: string, _in: ExprArg): Expr
   export function ContainsValue(value: ExprArg, _in: ExprArg): Expr
 
+  export function Select<T>(
+    index: number,
+    from: Expr.Page<T>,
+    _default?: ExprVal<T>
+  ): ToExpr<T>
   export function Select<T = any>(
     path: Expr.KeyPath,
     from: ExprVal<object>,

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -153,10 +153,10 @@ export module query {
     lambda_expr: ExprVal<Lambda<[Expr.IterableVal<T>]>>
   ): T
 
-  export function Filter<T>(
-    collection: Expr.Iterable<T>,
-    lambda_expr: Expr.Filter<T>
-  ): Expr<T[]>
+  export function Filter<T extends Expr.Iterable>(
+    collection: T,
+    lambda_expr: Expr.Filter<Expr.IterableVal<T>>
+  ): T
 
   // TODO
   export function Take(number: ExprArg, collection: ExprArg): Expr

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -15,12 +15,12 @@ import {
 
 export type ExprArg<T = unknown> = ExprVal<T> | Array<ExprVal<T>>
 
-export type CreateParams<T extends object> = ExprVal<{
+export type CreateParams<T extends object> = {
   data: T
   credentials?: JsonObject
   delegates?: JsonObject
   ttl?: Expr.Time
-}>
+}
 
 type Updatable<T extends object = any> =
   | DocumentRef<T>

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -212,7 +212,7 @@ export module query {
     collection: ExprArg
   ): Expr
 
-  export function Paginate<T extends JsonObject>(
+  export function Paginate<T>(
     set: SetRef<T>,
     params?: ExprVal<PaginateParams>
   ): Expr.Page<T>

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -172,8 +172,10 @@ export module query {
     params?: ExprVal<PaginateParams>
   ): Page<T>
 
-  // TODO
-  export function Exists(ref: ExprArg, ts?: ExprArg): Expr
+  export function Exists(
+    ref: Expr.Ref<any>,
+    ts?: ExprVal<number>
+  ): Expr<boolean>
 
   export function Create<T>(
     collection_ref: Expr.CollectionRef<T>,

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -89,13 +89,13 @@ export module query {
     condition: ExprVal<boolean>,
     then: ExprVal<T>,
     _else: ExprVal<U>
-  ): Expr<T | U>
+  ): ToExpr<T | U>
 
   export function If<T>(
     condition: ExprVal<boolean>,
     then: ExprVal<T>,
     _else: ExprVal<T>
-  ): Expr<T>
+  ): ToExpr<T>
 
   // TODO
   export function Do(...args: ExprArg[]): Expr

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -136,15 +136,10 @@ export module query {
   // TODO
   export function Query(lambda: ExprArg | Lambda): Expr
 
-  export function Map<T, Out>(
-    collection: Expr.Page<T>,
-    lambda_expr: ExprVal<Lambda<[T], Out>>
-  ): Expr.Page<Out>
-
-  export function Map<T, Out>(
-    collection: Exclude<Expr.Iterable<T>, Expr.ArrayRef>,
-    lambda_expr: ExprVal<Lambda<[T], Out>>
-  ): Expr<Out[]>
+  export function Map<T extends Expr.Mappable, Out>(
+    collection: T,
+    lambda_expr: ExprVal<Lambda<[Expr.IterableVal<T>], Out>>
+  ): Expr.MapResult<T, Out>
 
   // TODO
   export function Merge(

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -234,7 +234,7 @@ export module query {
   export function Match<T>(
     index: Expr.IndexRef<T>,
     ...terms: any[]
-  ): Expr.SetRef<T>
+  ): Expr.SetRef<Document<T>>
 
   // TODO
   export function Union(...sets: ExprArg[]): Expr

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -15,14 +15,14 @@ import {
 
 export type ExprArg<T = unknown> = ExprVal<T> | Array<ExprVal<T>>
 
-export type CreateParams<T extends JsonObject> = ExprVal<{
+export type CreateParams<T extends object> = ExprVal<{
   data: T
   credentials?: JsonObject
   delegates?: JsonObject
   ttl?: Expr.Time
 }>
 
-type Updatable<T extends JsonObject = any> =
+type Updatable<T extends object = any> =
   | DocumentRef<T>
   | CollectionRef<any, T>
   | IndexRef<any, T>
@@ -40,7 +40,7 @@ export type UpdateParams<T extends Updatable> = unknown & T extends DocumentRef<
   ? Omit<Partial<U>, 'ref' | 'ts'>
   : never
 
-export type CreateCollectionParams<Meta extends JsonObject = any> = {
+export type CreateCollectionParams<Meta extends object = any> = {
   name: string
   data?: Meta
   permissions?: JsonObject
@@ -48,7 +48,7 @@ export type CreateCollectionParams<Meta extends JsonObject = any> = {
   ttl_days?: number
 }
 
-export type CreateIndexParams<Meta extends JsonObject = any> = {
+export type CreateIndexParams<Meta extends object = any> = {
   name: string
   source: CollectionRef | any[]
   terms?: any[]
@@ -68,7 +68,7 @@ export type PaginateParams = {
   sources?: boolean
 }
 
-export type FunctionParams<Meta extends JsonObject = any> = {
+export type FunctionParams<Meta extends object = any> = {
   name: string
   body: JsonObject
   data?: Meta
@@ -76,7 +76,7 @@ export type FunctionParams<Meta extends JsonObject = any> = {
 }
 
 export module query {
-  export function Ref<T extends JsonObject>(
+  export function Ref<T extends object>(
     ref: CollectionRef<T>,
     id?: ExprVal<number | string>
   ): DocumentRef<T>
@@ -86,7 +86,7 @@ export module query {
   export function Abort(msg: ExprArg): Expr
   export function At(timestamp: ExprArg, expr: ExprArg): Expr
 
-  export function Let<T>(vars: ExprVal<JsonObject>, in_expr: Expr<T>): Expr<T>
+  export function Let<T>(vars: ExprVal<object>, in_expr: Expr<T>): Expr<T>
 
   // TODO
   export function Var(varName: ExprArg): Expr
@@ -199,7 +199,7 @@ export module query {
   export function IsCredentials(expr: ExprArg): Expr
   export function IsRole(expr: ExprArg): Expr
 
-  export function Get<T extends JsonObject>(
+  export function Get<T extends object>(
     ref: Ref<T> | SetRef<Ref<T>>,
     ts?: ExprVal<number | Expr.Time>
   ): Expr<T>
@@ -219,7 +219,7 @@ export module query {
 
   export function Exists(ref: Ref, ts?: ExprVal<number>): Expr<boolean>
 
-  export function Create<T extends JsonObject>(
+  export function Create<T extends object>(
     collection_ref: CollectionRef<T>,
     params: ExprVal<CreateParams<T>>
   ): Expr<Document<T>>
@@ -232,12 +232,12 @@ export module query {
   // TODO
   export function Replace(ref: ExprArg, params: ExprArg): Expr
 
-  export function Delete(
-    ref: Ref
+  export function Delete<T extends object>(
+    ref: Ref<T>
   ): Expr<{
-    database: string
-    role: string
-    data?: JsonObject
+    data?: T
+    role?: string
+    database?: string
     priority?: number
   }>
 
@@ -251,23 +251,21 @@ export module query {
   export function Remove(ref: ExprArg, ts: ExprArg, action: ExprArg): Expr
   export function CreateClass(params: ExprArg): Expr
 
-  export function CreateCollection<
-    T extends JsonObject,
-    Meta extends JsonObject = any
-  >(params: ExprVal<CreateCollectionParams<Meta>>): Expr<Collection<T, Meta>>
+  export function CreateCollection<T extends object, Meta extends object = any>(
+    params: ExprVal<CreateCollectionParams<Meta>>
+  ): Expr<Collection<T, Meta>>
 
   // TODO
   export function CreateDatabase(params: ExprArg): Expr
 
-  export function CreateIndex<
-    T extends JsonObject,
-    Meta extends JsonObject = any
-  >(params: ExprVal<CreateIndexParams<Meta>>): Expr<Index<T, Meta>>
+  export function CreateIndex<T extends object, Meta extends object = any>(
+    params: ExprVal<CreateIndexParams<Meta>>
+  ): Expr<Index<T, Meta>>
 
   // TODO
   export function CreateKey(params: ExprArg): Expr
 
-  export function CreateFunction<Return, Meta extends JsonObject = any>(
+  export function CreateFunction<Return, Meta extends object = any>(
     params: ExprVal<FunctionParams<Meta>>
   ): Expr<Function<Return>>
 
@@ -279,7 +277,7 @@ export module query {
   export function Singleton(ref: ExprArg): Expr
   export function Events(ref_set: ExprArg): Expr
 
-  export function Match<T extends JsonObject>(
+  export function Match<T extends object>(
     index: IndexRef<T>,
     ...terms: any[]
   ): SetRef<DocumentRef<T>>
@@ -370,19 +368,19 @@ export module query {
   export function Database(name: ExprArg, scope?: ExprArg): Expr
 
   // TODO: "scope" argument
-  export function Index<T extends JsonObject, Meta extends JsonObject = any>(
+  export function Index<T extends object, Meta extends object = any>(
     name: ExprVal<string>,
     scope?: ExprArg
   ): IndexRef<T, Meta>
 
   // TODO: "scope" argument
-  export function Collection<
-    T extends JsonObject,
-    Meta extends JsonObject = any
-  >(name: ExprVal<string>, scope?: ExprArg): CollectionRef<T, Meta>
+  export function Collection<T extends object, Meta extends object = any>(
+    name: ExprVal<string>,
+    scope?: ExprArg
+  ): CollectionRef<T, Meta>
 
   // TODO: "scope" argument
-  export function Function<Return, Meta extends JsonObject = any>(
+  export function Function<Return, Meta extends object = any>(
     name: ExprVal<string>,
     scope?: ExprArg
   ): FunctionRef<Return, Meta>
@@ -426,7 +424,7 @@ export module query {
   ): ToExpr<T>
   export function Select<T = any>(
     path: Expr.KeyPath,
-    from: ExprVal<JsonObject>,
+    from: ExprVal<object>,
     _default?: ExprVal<T>
   ): ToExpr<T>
 
@@ -499,7 +497,7 @@ export module query {
   // TODO
   export function MoveDatabase(from: ExprArg, to: ExprArg): Expr
 
-  export function Documents<T extends JsonObject>(
+  export function Documents<T extends object>(
     collection: CollectionRef<T>
   ): SetRef<DocumentRef<T>>
 

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -10,7 +10,7 @@ import Expr, {
 
 export type ExprArg<T = unknown> = ExprVal<T> | Array<ExprVal<T>>
 
-export type CreateParams<T> = ExprVal<{
+export type CreateParams<T extends object> = ExprVal<{
   data: T
   credentials?: object
   delegates?: object
@@ -53,7 +53,7 @@ export type FunctionParams = {
 }
 
 export module query {
-  export function Ref<T>(
+  export function Ref<T extends object>(
     ref: Expr.CollectionRef<T>,
     id?: ExprVal<number | string>
   ): Expr.DocumentRef<T>
@@ -155,7 +155,7 @@ export module query {
   export function IsCredentials(expr: ExprArg): Expr
   export function IsRole(expr: ExprArg): Expr
 
-  export function Get<T>(
+  export function Get<T extends object>(
     ref: Expr.Ref<T>,
     ts?: ExprVal<number | Expr.Time>
   ): Expr<T extends (infer U)[] ? U : T>
@@ -168,7 +168,7 @@ export module query {
     collection: ExprArg
   ): Expr
 
-  export function Paginate<T>(
+  export function Paginate<T extends object>(
     set: Expr.SetRef<T>,
     params?: ExprVal<PaginateParams>
   ): Page<Expr.Ref<T>>
@@ -178,7 +178,7 @@ export module query {
     ts?: ExprVal<number>
   ): Expr<boolean>
 
-  export function Create<T>(
+  export function Create<T extends object>(
     collection_ref: Expr.CollectionRef<T>,
     params: ExprVal<CreateParams<T>>
   ): Document<T>
@@ -206,14 +206,14 @@ export module query {
   export function Remove(ref: ExprArg, ts: ExprArg, action: ExprArg): Expr
   export function CreateClass(params: ExprArg): Expr
 
-  export function CreateCollection<T>(
+  export function CreateCollection<T extends object>(
     params: ExprVal<CreateCollectionParams>
   ): Expr<Collection<T>>
 
   // TODO
   export function CreateDatabase(params: ExprArg): Expr
 
-  export function CreateIndex<T>(
+  export function CreateIndex<T extends object>(
     params: ExprVal<CreateIndexParams>
   ): Expr<Index<T>>
 
@@ -232,7 +232,7 @@ export module query {
   export function Singleton(ref: ExprArg): Expr
   export function Events(ref_set: ExprArg): Expr
 
-  export function Match<T>(
+  export function Match<T extends object>(
     index: Expr.IndexRef<T>,
     ...terms: any[]
   ): Expr.SetRef<Document<T>>
@@ -323,13 +323,13 @@ export module query {
   export function Database(name: ExprArg, scope?: ExprArg): Expr
 
   // TODO: "scope" argument
-  export function Index<T>(
+  export function Index<T extends object>(
     name: ExprVal<string>,
     scope?: ExprArg
   ): Expr.IndexRef<T>
 
   // TODO: "scope" argument
-  export function Collection<T>(
+  export function Collection<T extends object>(
     name: ExprVal<string>,
     scope?: ExprArg
   ): Expr.CollectionRef<T>
@@ -443,7 +443,7 @@ export module query {
   // TODO
   export function MoveDatabase(from: ExprArg, to: ExprArg): Expr
 
-  export function Documents<T>(
+  export function Documents<T extends object>(
     collection: Expr.CollectionRef<T>
   ): Expr.SetRef<Document<T>>
 }

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -116,6 +116,11 @@ export module query {
   export function Query(lambda: ExprArg | Lambda): Expr
 
   export function Map<T, Out>(
+    collection: Expr.Page<T>,
+    lambda_expr: ExprVal<Lambda<[T], Out>>
+  ): Expr.Page<Out>
+
+  export function Map<T, Out>(
     collection: Exclude<Expr.Iterable<T>, Expr.ArrayRef>,
     lambda_expr: ExprVal<Lambda<[T], Out>>
   ): Expr<Out[]>

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -1,23 +1,24 @@
 import Expr, {
-  ExprVal,
-  Lambda,
-  Document,
   Collection,
-  Index,
+  Document,
+  ExprVal,
   Function,
+  Index,
+  Lambda,
   ToExpr,
 } from './Expr'
+import { JsonObject } from './json'
 
 export type ExprArg<T = unknown> = ExprVal<T> | Array<ExprVal<T>>
 
-export type CreateParams<T extends object> = ExprVal<{
+export type CreateParams<T extends JsonObject> = ExprVal<{
   data: T
-  credentials?: object
-  delegates?: object
+  credentials?: JsonObject
+  delegates?: JsonObject
   ttl?: Expr.Time
 }>
 
-type Updatable<T extends object = any> =
+type Updatable<T extends JsonObject = any> =
   | Expr.DocumentRef<T>
   | Expr.CollectionRef<any, T>
   | Expr.IndexRef<any, T>
@@ -27,29 +28,29 @@ export type UpdateParams<T extends Updatable> = unknown &
   T extends Expr.DocumentRef<infer U>
   ? {
       data?: Partial<U>
-      credentials?: object
-      delegates?: object
+      credentials?: JsonObject
+      delegates?: JsonObject
     }
   : T extends Expr.Ref<infer U>
   ? Omit<Partial<U>, 'ref' | 'ts'>
   : never
 
-export type CreateCollectionParams<Meta extends object = any> = {
+export type CreateCollectionParams<Meta extends JsonObject = any> = {
   name: string
   data?: Meta
-  permissions?: object
+  permissions?: JsonObject
   history_days?: number
   ttl_days?: number
 }
 
-export type CreateIndexParams<Meta extends object = any> = {
+export type CreateIndexParams<Meta extends JsonObject = any> = {
   name: string
   source: Expr.CollectionRef<any> | any[]
   terms?: any[]
   values?: any[]
   unique?: boolean
   serialized?: boolean
-  permissions?: object
+  permissions?: JsonObject
   data?: Meta
 }
 
@@ -62,15 +63,15 @@ export type PaginateParams = {
   sources?: boolean
 }
 
-export type FunctionParams<Meta extends object = any> = {
+export type FunctionParams<Meta extends JsonObject = any> = {
   name: string
-  body: object
+  body: JsonObject
   data?: Meta
   role?: any
 }
 
 export module query {
-  export function Ref<T extends object>(
+  export function Ref<T extends JsonObject>(
     ref: Expr.CollectionRef<T>,
     id?: ExprVal<number | string>
   ): Expr.DocumentRef<T>
@@ -80,7 +81,7 @@ export module query {
   export function Abort(msg: ExprArg): Expr
   export function At(timestamp: ExprArg, expr: ExprArg): Expr
 
-  export function Let<T>(vars: ExprVal<object>, in_expr: Expr<T>): Expr<T>
+  export function Let<T>(vars: ExprVal<JsonObject>, in_expr: Expr<T>): Expr<T>
 
   // TODO
   export function Var(varName: ExprArg): Expr
@@ -193,7 +194,7 @@ export module query {
   export function IsCredentials(expr: ExprArg): Expr
   export function IsRole(expr: ExprArg): Expr
 
-  export function Get<T extends object>(
+  export function Get<T extends JsonObject>(
     ref: Expr.Ref<T> | Expr.SetRef<Expr.Ref<T>>,
     ts?: ExprVal<number | Expr.Time>
   ): Expr<T>
@@ -206,7 +207,7 @@ export module query {
     collection: ExprArg
   ): Expr
 
-  export function Paginate<T extends object>(
+  export function Paginate<T extends JsonObject>(
     set: Expr.SetRef<T>,
     params?: ExprVal<PaginateParams>
   ): Expr.Page<T>
@@ -216,7 +217,7 @@ export module query {
     ts?: ExprVal<number>
   ): Expr<boolean>
 
-  export function Create<T extends object>(
+  export function Create<T extends JsonObject>(
     collection_ref: Expr.CollectionRef<T>,
     params: ExprVal<CreateParams<T>>
   ): Expr<Document<T>>
@@ -234,7 +235,7 @@ export module query {
   ): Expr<{
     database: string
     role: string
-    data?: object
+    data?: JsonObject
     priority?: number
   }>
 
@@ -248,21 +249,23 @@ export module query {
   export function Remove(ref: ExprArg, ts: ExprArg, action: ExprArg): Expr
   export function CreateClass(params: ExprArg): Expr
 
-  export function CreateCollection<T extends object, Meta extends object = any>(
-    params: ExprVal<CreateCollectionParams<Meta>>
-  ): Expr<Collection<T, Meta>>
+  export function CreateCollection<
+    T extends JsonObject,
+    Meta extends JsonObject = any
+  >(params: ExprVal<CreateCollectionParams<Meta>>): Expr<Collection<T, Meta>>
 
   // TODO
   export function CreateDatabase(params: ExprArg): Expr
 
-  export function CreateIndex<T extends object, Meta extends object = any>(
-    params: ExprVal<CreateIndexParams<Meta>>
-  ): Expr<Index<T, Meta>>
+  export function CreateIndex<
+    T extends JsonObject,
+    Meta extends JsonObject = any
+  >(params: ExprVal<CreateIndexParams<Meta>>): Expr<Index<T, Meta>>
 
   // TODO
   export function CreateKey(params: ExprArg): Expr
 
-  export function CreateFunction<Return, Meta extends object = any>(
+  export function CreateFunction<Return, Meta extends JsonObject = any>(
     params: ExprVal<FunctionParams<Meta>>
   ): Expr<Function<Return>>
 
@@ -274,7 +277,7 @@ export module query {
   export function Singleton(ref: ExprArg): Expr
   export function Events(ref_set: ExprArg): Expr
 
-  export function Match<T extends object>(
+  export function Match<T extends JsonObject>(
     index: Expr.IndexRef<T>,
     ...terms: any[]
   ): Expr.SetRef<Expr.DocumentRef<T>>
@@ -365,19 +368,19 @@ export module query {
   export function Database(name: ExprArg, scope?: ExprArg): Expr
 
   // TODO: "scope" argument
-  export function Index<T extends object, Meta extends object = any>(
+  export function Index<T extends JsonObject, Meta extends JsonObject = any>(
     name: ExprVal<string>,
     scope?: ExprArg
   ): Expr.IndexRef<T, Meta>
 
   // TODO: "scope" argument
-  export function Collection<T extends object, Meta extends object = any>(
-    name: ExprVal<string>,
-    scope?: ExprArg
-  ): Expr.CollectionRef<T, Meta>
+  export function Collection<
+    T extends JsonObject,
+    Meta extends JsonObject = any
+  >(name: ExprVal<string>, scope?: ExprArg): Expr.CollectionRef<T, Meta>
 
   // TODO: "scope" argument
-  export function Function<Return, Meta extends object = any>(
+  export function Function<Return, Meta extends JsonObject = any>(
     name: ExprVal<string>,
     scope?: ExprArg
   ): Expr.FunctionRef<Return, Meta>
@@ -423,7 +426,7 @@ export module query {
   ): ToExpr<T>
   export function Select<T = any>(
     path: Expr.KeyPath,
-    from: ExprVal<object>,
+    from: ExprVal<JsonObject>,
     _default?: ExprVal<T>
   ): ToExpr<T>
 
@@ -496,7 +499,7 @@ export module query {
   // TODO
   export function MoveDatabase(from: ExprArg, to: ExprArg): Expr
 
-  export function Documents<T extends object>(
+  export function Documents<T extends JsonObject>(
     collection: Expr.CollectionRef<T>
   ): Expr.SetRef<Expr.DocumentRef<T>>
 }

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -97,8 +97,29 @@ export module query {
     _else: ExprVal<T>
   ): ToExpr<T>
 
+  export function Do<T>(arg1: ExprVal<T>): ToExpr<T>
+  export function Do<T>(arg1: ExprVal, arg2: ExprVal<T>): ToExpr<T>
+  export function Do<T>(
+    arg1: ExprVal,
+    arg2: ExprVal,
+    arg3: ExprVal<T>
+  ): ToExpr<T>
+  export function Do<T>(
+    arg1: ExprVal,
+    arg2: ExprVal,
+    arg3: ExprVal,
+    arg4: ExprVal<T>
+  ): ToExpr<T>
+  export function Do<T>(
+    arg1: ExprVal,
+    arg2: ExprVal,
+    arg3: ExprVal,
+    arg4: ExprVal,
+    arg5: ExprVal<T>
+  ): ToExpr<T>
+  export function Do<T>(...args: ExprVal[]): ToExpr<T>
+
   // TODO
-  export function Do(...args: ExprArg[]): Expr
   export function Object(fields: ExprArg): Expr
 
   export function Lambda<In extends any[], Out>(

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -411,7 +411,7 @@ export module query {
   export function ContainsValue(value: ExprArg, _in: ExprArg): Expr
 
   export function Select<T = any>(
-    path: ExprVal<string | number> | Expr.KeyPath,
+    path: Expr.KeyPath,
     from: ExprVal<object>,
     _default?: ExprVal<T>
   ): ToExpr<T>

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -348,9 +348,13 @@ export module query {
   // TODO: "scope" argument
   export function Collections(scope?: ExprArg): Expr.SetRef<Collection<any>>
 
+  // TODO: "scope" argument
+  export function Indexes(scope?: ExprArg): Expr.SetRef<Index<any>>
+
+  // TODO: "scope" argument
+  export function Functions(scope?: ExprArg): Expr.SetRef<Function<any>>
+
   // TODO
-  export function Indexes(scope?: ExprArg): Expr
-  export function Functions(scope?: ExprArg): Expr
   export function Roles(scope?: ExprArg): Expr
   export function Keys(scope?: ExprArg): Expr
   export function Tokens(scope?: ExprArg): Expr

--- a/src/types/values.d.ts
+++ b/src/types/values.d.ts
@@ -1,22 +1,32 @@
 import Expr from './Expr'
+import { JsonObject } from './json'
 
 export module values {
-  export class Value extends Expr {
+  export class Value<T = any> extends Expr<T> {
     toJSON(): object
     inspect(): string
 
     readonly _isFaunaValue?: boolean
   }
 
-  export class Ref extends Value {
-    constructor(id: string, col?: Ref, db?: Ref)
+  export class Ref<T extends JsonObject = any> extends Value<Ref<T>> {
+    constructor(id: string, col?: CollectionRef<T>, db?: Ref)
 
     id: string
-    collection?: Ref
-    class?: Ref
+    collection?: CollectionRef<T>
     database?: Ref
 
     readonly _isFaunaRef?: boolean
+
+    /** This enforces type nominality. */
+    protected _ref: { data: T }
+  }
+
+  export class SetRef<T = any> extends Value {
+    constructor(value: string)
+
+    /** This enforces type nominality. */
+    protected _ref: { type: 'Set'; data: T }
   }
 
   export class Native {
@@ -26,10 +36,6 @@ export module values {
     static readonly KEYS: Ref
     static readonly FUNCTIONS: Ref
     static readonly ACCESS_PROVIDERS: Ref
-  }
-
-  export class SetRef extends Value {
-    constructor(value: string)
   }
 
   export class FaunaTime extends Value {
@@ -55,16 +61,100 @@ export module values {
   export class Query extends Value {
     constructor(value: object)
   }
+}
 
-  export type Document<T = object> = {
-    ref: Ref
-    ts: number
-    data: T
-  }
+/** The materialized data of a page. */
+export interface Page<T> {
+  data: T[]
+  after?: Expr
+  before?: Expr
+}
 
-  export type Page<T> = {
-    data: T[]
-    after?: Expr
-    before?: Expr
-  }
+/** The materialized data of a collection. */
+export interface Collection<
+  T extends JsonObject,
+  Meta extends JsonObject = any
+> extends JsonObject {
+  ref: CollectionRef<T, Meta>
+  ts: number
+  name: string
+  data: Meta
+  permissions?: JsonObject
+  history_days: number | null
+  ttl_days?: number
+}
+
+/** The materialized data of a document. */
+export interface Document<T extends JsonObject> extends JsonObject {
+  data: T
+  ref: DocumentRef<T>
+  ts: number
+}
+
+/** The materialized data of an index. */
+export interface Index<T extends JsonObject, Meta extends JsonObject = any>
+  extends JsonObject {
+  ref: IndexRef<T, Meta>
+  ts: number
+  name: string
+  data: Meta
+  source: CollectionRef<any> | any[]
+  partitions: number
+  active: boolean
+  serialized?: boolean
+  unique?: boolean
+  terms?: any[]
+  values?: any[]
+  permissions?: JsonObject
+}
+
+/** The materialized data of a function. */
+export interface Function<Return, Meta extends JsonObject = any>
+  extends JsonObject {
+  ref: FunctionRef<Return, Meta>
+  ts: number
+  name: string
+  data: Meta
+  body: JsonObject
+  role?: any
+}
+
+declare const Ref: typeof values.Ref
+
+export type Ref<T extends JsonObject = any> = values.Ref<T>
+export type SetRef<T = any> = values.SetRef<T>
+
+/** The ref to a collection. */
+export abstract class CollectionRef<
+  T extends JsonObject,
+  Meta extends JsonObject = any
+> extends Ref<Collection<T, Meta>> {
+  /** This enforces type nominality. */
+  protected _ref: { type: 'Collection'; data: Collection<T, Meta> }
+}
+
+/** The ref to a document. */
+export abstract class DocumentRef<T extends JsonObject> extends Ref<
+  Document<T>
+> {
+  /** This enforces type nominality. */
+  protected _ref: { type: 'Document'; data: Document<T> }
+}
+
+/** The ref to an index. */
+export abstract class IndexRef<
+  T extends JsonObject,
+  Meta extends JsonObject = any
+> extends Ref<Index<T, Meta>> {
+  /** This enforces type nominality. */
+  protected _ref: { type: 'Index'; data: Index<T, Meta> }
+}
+
+/** The ref to a function. */
+export abstract class FunctionRef<
+  Return,
+  Meta extends JsonObject = any
+> extends Ref<Function<Return, Meta>> {
+  /** This enforces type nominality. */
+  protected _ref: { type: 'Function'; data: Function<Return, Meta> }
 }

--- a/src/types/values.d.ts
+++ b/src/types/values.d.ts
@@ -72,7 +72,7 @@ export interface Page<T> {
 
 /** The materialized data of a collection. */
 export interface Collection<
-  T extends JsonObject,
+  T extends JsonObject = any,
   Meta extends JsonObject = any
 > extends JsonObject {
   ref: CollectionRef<T, Meta>
@@ -85,20 +85,22 @@ export interface Collection<
 }
 
 /** The materialized data of a document. */
-export interface Document<T extends JsonObject> extends JsonObject {
+export interface Document<T extends JsonObject = any> extends JsonObject {
   data: T
   ref: DocumentRef<T>
   ts: number
 }
 
 /** The materialized data of an index. */
-export interface Index<T extends JsonObject, Meta extends JsonObject = any>
-  extends JsonObject {
+export interface Index<
+  T extends JsonObject = any,
+  Meta extends JsonObject = any
+> extends JsonObject {
   ref: IndexRef<T, Meta>
   ts: number
   name: string
   data: Meta
-  source: CollectionRef<any> | any[]
+  source: CollectionRef | any[]
   partitions: number
   active: boolean
   serialized?: boolean
@@ -109,7 +111,7 @@ export interface Index<T extends JsonObject, Meta extends JsonObject = any>
 }
 
 /** The materialized data of a function. */
-export interface Function<Return, Meta extends JsonObject = any>
+export interface Function<Return = any, Meta extends JsonObject = any>
   extends JsonObject {
   ref: FunctionRef<Return, Meta>
   ts: number
@@ -126,7 +128,7 @@ export type SetRef<T = any> = values.SetRef<T>
 
 /** The ref to a collection. */
 export abstract class CollectionRef<
-  T extends JsonObject,
+  T extends JsonObject = any,
   Meta extends JsonObject = any
 > extends Ref<Collection<T, Meta>> {
   /** This enforces type nominality. */
@@ -143,7 +145,7 @@ export abstract class DocumentRef<T extends JsonObject> extends Ref<
 
 /** The ref to an index. */
 export abstract class IndexRef<
-  T extends JsonObject,
+  T extends JsonObject = any,
   Meta extends JsonObject = any
 > extends Ref<Index<T, Meta>> {
   /** This enforces type nominality. */
@@ -152,7 +154,7 @@ export abstract class IndexRef<
 
 /** The ref to a function. */
 export abstract class FunctionRef<
-  Return,
+  Return = any,
   Meta extends JsonObject = any
 > extends Ref<Function<Return, Meta>> {
   /** This enforces type nominality. */

--- a/src/types/values.d.ts
+++ b/src/types/values.d.ts
@@ -9,7 +9,7 @@ export module values {
     readonly _isFaunaValue?: boolean
   }
 
-  export class Ref<T extends JsonObject = any> extends Value<Ref<T>> {
+  export class Ref<T extends object = any> extends Value<Ref<T>> {
     constructor(id: string, col?: CollectionRef<T>, db?: Ref)
 
     id: string
@@ -71,10 +71,7 @@ export interface Page<T> {
 }
 
 /** The materialized data of a collection. */
-export interface Collection<
-  T extends JsonObject = any,
-  Meta extends JsonObject = any
-> extends JsonObject {
+export interface Collection<T extends object = any, Meta extends object = any> {
   ref: CollectionRef<T, Meta>
   ts: number
   name: string
@@ -85,17 +82,14 @@ export interface Collection<
 }
 
 /** The materialized data of a document. */
-export interface Document<T extends JsonObject = any> extends JsonObject {
+export interface Document<T extends object = any> {
   data: T
   ref: DocumentRef<T>
   ts: number
 }
 
 /** The materialized data of an index. */
-export interface Index<
-  T extends JsonObject = any,
-  Meta extends JsonObject = any
-> extends JsonObject {
+export interface Index<T extends object = any, Meta extends object = any> {
   ref: IndexRef<T, Meta>
   ts: number
   name: string
@@ -111,8 +105,7 @@ export interface Index<
 }
 
 /** The materialized data of a function. */
-export interface Function<Return = any, Meta extends JsonObject = any>
-  extends JsonObject {
+export interface Function<Return = any, Meta extends object = any> {
   ref: FunctionRef<Return, Meta>
   ts: number
   name: string
@@ -123,30 +116,28 @@ export interface Function<Return = any, Meta extends JsonObject = any>
 
 declare const Ref: typeof values.Ref
 
-export type Ref<T extends JsonObject = any> = values.Ref<T>
+export type Ref<T extends object = any> = values.Ref<T>
 export type SetRef<T = any> = values.SetRef<T>
 
 /** The ref to a collection. */
 export abstract class CollectionRef<
-  T extends JsonObject = any,
-  Meta extends JsonObject = any
+  T extends object = any,
+  Meta extends object = any
 > extends Ref<Collection<T, Meta>> {
   /** This enforces type nominality. */
   protected _ref: { type: 'Collection'; data: Collection<T, Meta> }
 }
 
 /** The ref to a document. */
-export abstract class DocumentRef<T extends JsonObject> extends Ref<
-  Document<T>
-> {
+export abstract class DocumentRef<T extends object> extends Ref<Document<T>> {
   /** This enforces type nominality. */
   protected _ref: { type: 'Document'; data: Document<T> }
 }
 
 /** The ref to an index. */
 export abstract class IndexRef<
-  T extends JsonObject = any,
-  Meta extends JsonObject = any
+  T extends object = any,
+  Meta extends object = any
 > extends Ref<Index<T, Meta>> {
   /** This enforces type nominality. */
   protected _ref: { type: 'Index'; data: Index<T, Meta> }
@@ -155,7 +146,7 @@ export abstract class IndexRef<
 /** The ref to a function. */
 export abstract class FunctionRef<
   Return = any,
-  Meta extends JsonObject = any
+  Meta extends object = any
 > extends Ref<Function<Return, Meta>> {
   /** This enforces type nominality. */
   protected _ref: { type: 'Function'; data: Function<Return, Meta> }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,11 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es5",
-        "noImplicitAny": false,
-        "sourceMap": false
-    },
-    "files": [
-      "index.d.ts"
-    ],
-    "exclude": [
-        "node_modules"
-    ]
+  "compilerOptions": {
+    "lib": ["es2015", "dom"],
+    "module": "commonjs",
+    "target": "es5",
+    "noImplicitAny": false,
+    "sourceMap": false
+  },
+  "files": ["index.d.ts"],
+  "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "lib": ["es2015", "dom"],
     "module": "commonjs",
     "target": "es5",
+    "strict": true,
     "noImplicitAny": false,
     "sourceMap": false
   },


### PR DESCRIPTION
#### ⚠️ This is a work-in-progress. So far, only the functions that I use have improved types. All contributions are welcome! Just open a PR [here](https://github.com/aleclarson/faunadb-js) that targets the `types` branch. 🍻 

These functions are *possibly* finished (please review them):
- `q.Add`
- `q.Call`
- ~`q.Class`~ (deprecated)
- ~`q.Classes`~  (deprecated)
- `q.Collection`
- `q.Collections`
- `q.ContainsPath`
- `q.Create`
- `q.CreateCollection`
- `q.CreateFunction`
- `q.CreateIndex`
- `q.Delete`
- `q.Do`
- `q.Documents`
- `q.Equals`
- `q.Exists`
- `q.Filter`
- `q.Foreach`
- `q.Function`
- `q.Functions`
- `q.Get`
- `q.If`
- `q.Index`
- `q.Indexes`
- `q.IsEmpty`
- `q.Lambda`
- `q.Let`
- `q.Map`
- `q.Match`
- `q.Not`
- `q.Paginate`
- `q.Ref`
- `q.Select`
- `q.Time`
- `q.Update`

Unlisted functions haven't been touched yet.

When called, these functions *should* have their type parameters defined explicitly:
- `q.Index<MyDocument>(...)`
- `q.Collection<MyDocument>(...)`
- `q.CreateIndex<MyDocument>(...)`
- `q.CreateCollection<MyDocument>(...)`
- `q.Function<MyReturn>(...)`
- `q.CreateFunction<MyReturn>(...)`
- `q.Select<MyResult>(...)`
