### PR TITLE
FE-484 | Add queryTimeout to Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,16 +153,22 @@ const client = new faunadb.Client({
 })
 ```
 
-On the other hand, using the client's `queryTimeout` dictates how long FaunaDB will process the request on the server before timing out if it hasn't finished running the operation. This can be done in two different ways:
+On the other hand, using the client's `queryTimeout` dictates how long FaunaDB will process the request on the server before timing out if it hasn't finished running the operation. This can be done in three different ways:
 
 ```javascript
-// 1. Setting the value on the client instance
+// 1. Setting the value when instantiating a new client
+const client = new faunadb.Client({
+  queryTimeout: 2000,
+  secret: 'YOUR_FAUNADB_SECRET',
+})
+
+// 2. Setting the value on the client instance
 const client = new faunadb.Client({
   secret: 'YOUR_FAUNADB_SECRET',
 })
 client.queryTimeout(200)
 
-// 2. Specifying the value per-query
+// 3. Specifying the value per-query
 var data = client.query(q.Paginate(q.Collections()), {
   queryTimeout: 100,
 })

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The client can be configured to handle timeouts in two different ways:
 1. Add a `timeout` field to the `options` block when instantiating the client
 2. By setting a `queryTimeout` on the client (or passing the value to the client's `.query()` method directly)
 
-The first option (i.e. `timeout`) represents a HTTP timeout on the client side. Represented in milliseconds, the client will wait the specified period before timing out if it has yet to receive data.
+The first option (i.e. `timeout`) represents a HTTP timeout on the client side. Represented in milliseconds, the client will wait the specified period before timing out if it has yet to receive a response.
 
 ```javascript
 const client = new faunadb.Client({

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The client can be configured to handle timeouts in two different ways:
 1. Add a `timeout` field to the `options` block when instantiating the client
 2. By setting a `queryTimeout` on the client (or passing the value to the client's `.query()` method directly)
 
-The first option (i.e. `timeout`) represents a HTTP timeout on the client side. Represented in milliseconds, the client will wait the specified period before timing out if it has yet to receive a response.
+The first option (i.e. `timeout`) represents a HTTP timeout on the client side. Defined in milliseconds, the client will wait the specified period before timing out if it has yet to receive a response.
 
 ```javascript
 const client = new faunadb.Client({

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ const client = new faunadb.Client({
 })
 ```
 
-On the other hand, using the client's `queryTimeout` dictates how long FaunaDB will process the request on the server-side before timing out if it hasn't finished it's lookup and/or returned data. This can be done in two different ways:
+On the other hand, using the client's `queryTimeout` dictates how long FaunaDB will process the request on the server before timing out if it hasn't finished running the operation. This can be done in two different ways:
 
 ```javascript
 // 1. Setting the value on the client instance

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ const client = new faunadb.Client({
 })
 ```
 
-On the other hand, using the client's `queryTimeout` dictates how long FaunaDB will process the request on the server before timing out if it hasn't finished running the operation. This can be done in three different ways:
+On the other hand, using the client's `queryTimeout` dictates how long FaunaDB will process the request on the server before timing out if it hasn't finished running the operation. This can be done in two different ways:
 
 ```javascript
 // 1. Setting the value when instantiating a new client
@@ -162,19 +162,13 @@ const client = new faunadb.Client({
   secret: 'YOUR_FAUNADB_SECRET',
 })
 
-// 2. Setting the value on the client instance
-const client = new faunadb.Client({
-  secret: 'YOUR_FAUNADB_SECRET',
-})
-client.queryTimeout(200)
-
-// 3. Specifying the value per-query
+// 2. Specifying the value per-query
 var data = client.query(q.Paginate(q.Collections()), {
   queryTimeout: 100,
 })
 ```
 
-**Note:** When passing a `queryTimeout` value to `client.query()` as part of the `options` object, it will take precendence over any value set on the client using `client.queryTimeout()`.
+**Note:** When passing a `queryTimeout` value to `client.query()` as part of the `options` object, it will take precendence over any value set on the client when instantiating it.
 
 #### Per-query options
 

--- a/README.md
+++ b/README.md
@@ -137,9 +137,42 @@ helper
 [See the JSDocs](https://fauna.github.com/faunadb-js/PageHelper.html) for
 more information on the pagination helper.
 
+#### Timeouts
+
+The client can be configured to handle timeouts in two different ways:
+
+1. Add a `timeout` field to the `options` block when instantiating the client
+2. By setting a `queryTimeout` on the client (or passing the value to the client's `.query()` method directly)
+
+The first option (i.e. `timeout`) represents a HTTP timeout on the client side. Represented in milliseconds, the client will wait the specified period before timing out if it has yet to receive data.
+
+```javascript
+const client = new faunadb.Client({
+  secret: 'YOUR_FAUNADB_SECRET',
+  timeout: 100,
+})
+```
+
+On the other hand, using the client's `queryTimeout` dictates how long FaunaDB will process the request on the server-side before timing out if it hasn't finished it's lookup and/or returned data. This can be done in two different ways:
+
+```javascript
+// 1. Setting the value on the client instance
+const client = new faunadb.Client({
+  secret: 'YOUR_FAUNADB_SECRET',
+})
+client.queryTimeout(200)
+
+// 2. Specifying the value per-query
+var data = client.query(q.Paginate(q.Collections()), {
+  queryTimeout: 100,
+})
+```
+
+**Note:** When passing a `queryTimeout` value to `client.query()` as part of the `options` object, it will take precendence over any value set on the client using `client.queryTimeout()`.
+
 #### Per-query options
 
-Some options (currently only `secret`) can be overriden on a per-query basis:
+Some options (currently only `secret` and `queryTimout`) can be overriden on a per-query basis:
 
 ```javascript
 var createP = client.query(
@@ -156,6 +189,12 @@ var helper = client.paginate(
     secret: 'YOUR_FAUNADB_SECRET',
   }
 )
+```
+
+```javascript
+var data = client.query(q.Paginate(q.Collections()), {
+  queryTimeout: 100,
+})
 ```
 
 #### Custom Fetch

--- a/src/Client.js
+++ b/src/Client.js
@@ -53,6 +53,8 @@ var parse = require('url-parse')
  *   Configures http/https keepAlive option (ignored in browser environments)
  * @param {?fetch} options.fetch
  *   a fetch compatible [API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for making a request
+ * @param {?number} options.queryTimeout
+ *   Sets the maximum amount of time (in milliseconds) for query execution on the server,
  */
 function Client(options) {
   var isNodeEnv = typeof window === 'undefined'

--- a/src/Client.js
+++ b/src/Client.js
@@ -108,8 +108,7 @@ Client.prototype.query = function(expression, options) {
 /**
  * Sets the maximum amount of time for query execution on the server.
  * Non-null values are sent to the server as the 'X-Query-Timeout' header.
- *   Length of time expressed in milliseconds
- * @param {number} timeout
+ * @param {number} timeout Length of time expressed in milliseconds
  */
 Client.prototype.queryTimeout = function(timeout) {
   this._queryTimeout = timeout

--- a/src/Client.js
+++ b/src/Client.js
@@ -227,6 +227,11 @@ Client.prototype._performRequest = function(
   url.set('query', query)
   options = defaults(options, {})
   var secret = options.secret || this._secret
+  var queryTimeout = this._queryTimeout
+
+  if (options && options.queryTimeout) {
+    queryTimeout = options.queryTimeout
+  }
 
   return this._fetch(url.href, {
     agent: this._keepAliveEnabledAgent,

--- a/src/Client.js
+++ b/src/Client.js
@@ -108,14 +108,6 @@ function Client(options) {
 Client.prototype.query = function(expression, options) {
   return this._execute('POST', '', query.wrap(expression), null, options)
 }
-/**
- * Sets the maximum amount of time for query execution on the server.
- * Non-null values are sent to the server as the 'X-Query-Timeout' header.
- * @param {number} timeout Length of time expressed in milliseconds
- */
-Client.prototype.queryTimeout = function(timeout) {
-  this._queryTimeout = timeout
-}
 
 /**
  * Returns a {@link PageHelper} for the given Query expression.

--- a/src/Client.js
+++ b/src/Client.js
@@ -80,6 +80,7 @@ function Client(options) {
   this._lastSeen = null
   this._headers = opts.headers
   this._fetch = opts.fetch || require('cross-fetch')
+  this._queryTimeout = null
 
   if (isNodeEnv && opts.keepAlive) {
     this._keepAliveEnabledAgent = new (isHttps
@@ -103,6 +104,15 @@ function Client(options) {
 
 Client.prototype.query = function(expression, options) {
   return this._execute('POST', '', query.wrap(expression), null, options)
+}
+/**
+ * Sets the maximum amount of time for query execution on the server.
+ * Non-null values are sent to the server as the 'X-Query-Timeout' header.
+ *   Length of time expressed in milliseconds
+ * @param {number} timeout
+ */
+Client.prototype.queryTimeout = function(timeout) {
+  this._queryTimeout = timeout
 }
 
 /**

--- a/src/Client.js
+++ b/src/Client.js
@@ -66,6 +66,7 @@ function Client(options) {
     keepAlive: true,
     headers: {},
     fetch: undefined,
+    queryTimeout: null,
   })
   var isHttps = opts.scheme === 'https'
 
@@ -80,7 +81,7 @@ function Client(options) {
   this._lastSeen = null
   this._headers = opts.headers
   this._fetch = opts.fetch || require('cross-fetch')
-  this._queryTimeout = null
+  this._queryTimeout = opts.queryTimeout
 
   if (isNodeEnv && opts.keepAlive) {
     this._keepAliveEnabledAgent = new (isHttps

--- a/src/Client.js
+++ b/src/Client.js
@@ -242,7 +242,7 @@ Client.prototype._performRequest = function(
       'X-FaunaDB-API-Version': APIVersion,
       'X-Fauna-Driver': 'Javascript',
       'X-Last-Seen-Txn': this._lastSeen,
-      'X-Query-Timeout': this._queryTimeout,
+      'X-Query-Timeout': queryTimeout,
     }),
     method: method,
     timeout: this._timeout,

--- a/src/Client.js
+++ b/src/Client.js
@@ -237,6 +237,7 @@ Client.prototype._performRequest = function(
       'X-FaunaDB-API-Version': APIVersion,
       'X-Fauna-Driver': 'Javascript',
       'X-Last-Seen-Txn': this._lastSeen,
+      'X-Query-Timeout': this._queryTimeout,
     }),
     method: method,
     timeout: this._timeout,

--- a/src/Client.js
+++ b/src/Client.js
@@ -226,7 +226,7 @@ Client.prototype._performRequest = function(
   url.set('pathname', path)
   url.set('query', query)
   options = defaults(options, {})
-  const secret = options.secret || this._secret
+  var secret = options.secret || this._secret
 
   return this._fetch(url.href, {
     agent: this._keepAliveEnabledAgent,

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -180,20 +180,6 @@ describe('Client', () => {
     )
   })
 
-  test('set query timeout using client.queryTimeout()', async () => {
-    const customQueryTimeout = 1000
-    const mockedFetch = mockFetch()
-    const client = new Client({ fetch: mockedFetch })
-
-    client.queryTimeout(customQueryTimeout)
-    await client.query(query.Databases())
-
-    expect(mockedFetch).toBeCalledTimes(1)
-    expect(mockedFetch.mock.calls[0][1].headers['X-Query-Timeout']).toEqual(
-      customQueryTimeout
-    )
-  })
-
   test('set query timeout using client.query()', async () => {
     const overrideQueryTimeout = 5000
     const baseQueryTimeout = 1000

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -132,7 +132,7 @@ describe('Client', () => {
     expect(client._queryTimeout).toEqual(2000)
   })
 
-  test.only('properly sets query timeout header', async () => {
+  test('properly sets query timeout header', async () => {
     const fetch = jest.fn((expr, opts) => {
       expect(opts.headers['X-Query-Timeout']).toEqual(2000)
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -123,6 +123,14 @@ describe('Client', () => {
     await client.ping()
     expect(fetch).toBeCalled()
   })
+
+  test('set queryTimeout on client instance', () => {
+    client.queryTimeout(1000)
+    expect(client._queryTimeout).toEqual(1000)
+
+    client.queryTimeout(2000)
+    expect(client._queryTimeout).toEqual(2000)
+  })
 })
 
 function assertHeader(headers, name) {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -182,11 +182,9 @@ describe('Client', () => {
 
   test('set query timeout using client.query()', async () => {
     const overrideQueryTimeout = 5000
-    const baseQueryTimeout = 1000
     const mockedFetch = mockFetch()
     const client = new Client({ fetch: mockedFetch })
 
-    client.queryTimeout(baseQueryTimeout)
     await client.query(query.Databases(), {
       queryTimeout: overrideQueryTimeout,
     })

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -151,6 +151,35 @@ describe('Client', () => {
     expect(mockedFetch.mock.calls[0][1].timeout).toEqual(customTimeout * 1000)
   })
 
+  test('instantiate client using default queryTimeout', async () => {
+    const mockedFetch = mockFetch()
+    const clientWithDefaultTimeout = new Client({
+      fetch: mockedFetch,
+    })
+
+    await clientWithDefaultTimeout.query(query.Databases())
+
+    expect(mockedFetch).toBeCalledTimes(1)
+    expect(
+      mockedFetch.mock.calls[0][1].headers['X-Query-Timeout']
+    ).not.toBeDefined()
+  })
+
+  test('instantiate client using custom queryTimeout', async () => {
+    const mockedFetch = mockFetch()
+    const clientWithCustomTimeout = new Client({
+      fetch: mockedFetch,
+      queryTimeout: 3000,
+    })
+
+    await clientWithCustomTimeout.query(query.Databases())
+
+    expect(mockedFetch).toBeCalledTimes(1)
+    expect(mockedFetch.mock.calls[0][1].headers['X-Query-Timeout']).toEqual(
+      3000
+    )
+  })
+
   test('set query timeout using client.queryTimeout()', async () => {
     const customQueryTimeout = 1000
     const mockedFetch = mockFetch()
@@ -165,7 +194,7 @@ describe('Client', () => {
     )
   })
 
-  test('set query timeout using client.queryTimeout()', async () => {
+  test('set query timeout using client.query()', async () => {
     const overrideQueryTimeout = 5000
     const baseQueryTimeout = 1000
     const mockedFetch = mockFetch()

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -131,6 +131,30 @@ describe('Client', () => {
     client.queryTimeout(2000)
     expect(client._queryTimeout).toEqual(2000)
   })
+
+  test.only('properly sets query timeout header', async () => {
+    const fetch = jest.fn((expr, opts) => {
+      expect(opts.headers['X-Query-Timeout']).toEqual(2000)
+
+      return Promise.resolve({
+        headers: new Set(),
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              data: ['Collection("my_collection")'],
+            })
+          ),
+      })
+    })
+
+    const testClient = util.getClient({
+      fetch,
+    })
+
+    await testClient.query(query.Paginate(query.Collections()), {
+      queryTimeout: 2000,
+    })
+  })
 })
 
 function assertHeader(headers, name) {


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-484)

**To Do:**

- [x] ~Add some tests to cover these changes~

The work in this PR does the following:
1. Adds a `queryTimeout()` function to the `Client.prototype`, which allows users to set the `_queryTimeout` field on the Client instance

```javascript
const client = new faunadb.Client({
  secret: 'MY_KEY'
})
client.queryTimeout(200)
```

2. Allows a user to pass a `queryTimeout` value to the `client.query()` function call, which will override `Client._queryTimeout` if it also has a value

```javascript
const data = client.query(q.Paginate(q.Collections()), { queryTimeout: 100 })
```

### How to test
To test locally, I did the following:

1. In the local `faunadb-js` directory, run `yarn link`
2. In the local `console` repo, run `yarn link faunadb` 
3. At the root of `console`, create a `test.js`
4. Import `faunadb` and try to use the new functionality. Test by running `node test.js`.
5. In `faunadb-js`, add some `console.log`s to `Client.prototype._performRequest` to inspect the outgoing headers

My script looked like this:
```javascript
const faunadb = require('faunadb'),
  q = faunadb.query

const client = new faunadb.Client({
  secret: 'MY_KEY'
})
client.queryTimeout(200)

const data = client.query(q.Paginate(q.Collections()), { queryTimeout: 100 })
data.then(res => console.log(res)).catch(err => console.log(err))
```