### PR TITLE
Fixing FaunaHTTPError constructor typing mismatch 

### DIFF
--- a/src/types/errors.d.ts
+++ b/src/types/errors.d.ts
@@ -13,7 +13,7 @@ export module errors {
   export class FaunaHTTPError extends FaunaError {
     static raiseForStatusCode(requestResult: RequestResult): void
 
-    constructor(requestResult: RequestResult)
+    constructor(name: string, requestResult: RequestResult)
 
     requestResult: RequestResult
     errors(): object


### PR DESCRIPTION
Constructor typing for FaunaHTTPError in `errors.d.ts` doesn't match the constructor typing in `errors.js`, which makes subclassing FaunaHTTPError very difficult.  This PR seems to fix the issue without causing other problems, though I will confess that my testing has been minimal.  

### Notes
[Jira Ticket]()
Fixes  #273 

### How to test

### Screenshots