### PR TITLE
chore(release): bump to 2.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.14.1
+
+- Fix type mismatch for FaunaHTTPError constructor
+- Rollback ESM support breaking changes
+
 ## 2.14.0
 
 - Add client-specified query timeout

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "FaunaDB Javascript driver for Node.JS and Browsers",
   "homepage": "https://fauna.com",
   "repository": "fauna/faunadb-js",


### PR DESCRIPTION
### Notes
**Changes**
- Fix type mismatch for FaunaHTTPError constructor
- Rollback ESM support breaking changes