### PR TITLE
FE-340 | feat: add description to FaunaError

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -18,7 +18,7 @@ var util = require('util')
  * @extends Error
  * @constructor
  */
-function FaunaError(name, message) {
+function FaunaError(name, message, description) {
   Error.call(this)
 
   /**
@@ -32,6 +32,12 @@ function FaunaError(name, message) {
    * @type {string}
    */
   this.message = message
+
+  /**
+   * Description for this exception.
+   * @type {string}
+   */
+  this.description = description
 }
 
 util.inherits(FaunaError, Error)
@@ -110,7 +116,9 @@ function FaunaHTTPError(name, requestResult) {
   var response = requestResult.responseContent
   var errors = response.errors
   var message = errors.length === 0 ? '(empty "errors")' : errors[0].code
-  FaunaError.call(this, name, message)
+  var description =
+    errors.length === 0 ? '(empty "errors")' : errors[0].description
+  FaunaError.call(this, name, message, description)
 
   /**
    * A wrapped {@link RequestResult} object, containing the request and response


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-340)

This PR updates the error object returned from the JS Driver when a query fails for whatever reason:
- Takes the `description` from `RequestResult.responseRaw.errors` and adds it to the root of the response object

The ticket also asks for the `code` field from `RequestResult.responseRaw.errors` to be at the root of the object, but it already is (the field is named `message`). 


### How to test
To test, I did the following:
1. Run `yarn link` in `faunadb-js`
2. Run `yarn link faunadb` in `console2`
3. In `console2`, create a `test.js` at the root of the project
4. Use the snippet below and run `node test.js` to execute the script
```javascript
const faunadb = require('faunadb')
const { query: q } = faunadb

const client = new faunadb.Client({ secret: 'ABCD' })
const request = client.query(q.Divide(null, 2))

request
  .then(res => {
    console.log(res)
  })
  .catch(err => {
    console.log(err)
  })

```

### Screenshots
![image](https://user-images.githubusercontent.com/59929076/82364994-08581080-99de-11ea-8385-778365fe7c76.png)
