### PR TITLE
FE-540 | Mis-cased FQL function names

### DIFF
--- a/src/Expr.js
+++ b/src/Expr.js
@@ -39,6 +39,14 @@ var varArgsFunctions = [
   'And',
   'Or',
 ]
+
+// FQL function names come across the wire as all lowercase letters
+// (like the key of this object). Not all are properly snake-cased
+// on the Core side, which causes improper capitalizations.
+//
+// JS Driver patch: https://faunadb.atlassian.net/browse/FE-540
+// Core update: https://faunadb.atlassian.net/browse/ENG-2110
+
 var specialCases = {
   containsstr: 'ContainsStr',
   containsstrregex: 'ContainsStrRegex',
@@ -128,6 +136,8 @@ var exprToString = function(expr, caller) {
   var keys = Object.keys(expr)
   var fn = keys[0]
 
+  // For FQL functions with special formatting concerns, we
+  // use the specialCases object above to define their casing.
   if (fn in specialCases) fn = specialCases[fn]
 
   fn = fn

--- a/src/Expr.js
+++ b/src/Expr.js
@@ -40,11 +40,26 @@ var varArgsFunctions = [
   'Or',
 ]
 var specialCases = {
-  is_nonempty: 'is_non_empty',
-  lt: 'LT',
-  lte: 'LTE',
+  containsstr: 'ContainsStr',
+  containsstrregex: 'ContainsStrRegex',
+  endswith: 'EndsWith',
+  findstr: 'FindStr',
+  findstrregex: 'FindStrRegex',
   gt: 'GT',
   gte: 'GTE',
+  is_nonempty: 'is_non_empty',
+  lowercase: 'LowerCase',
+  lt: 'LT',
+  lte: 'LTE',
+  ltrim: 'LTrim',
+  rtrim: 'RTrim',
+  regexescape: 'RegexEscape',
+  replacestr: 'ReplaceStr',
+  replacestrregex: 'ReplaceStrRegex',
+  startswith: 'StartsWith',
+  substring: 'SubString',
+  titlecase: 'TitleCase',
+  uppercase: 'UpperCase',
 }
 
 var exprToString = function(expr, caller) {


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-540)

The following FQL function names were improperly cased in the UDF form due to the logic below:

- `ContainsStr`
- `ContainsStrRegex`
- `StartsWith`
- `EndsWith`
- `RegexEscape`
- `FindStrRegex`
- `ReplaceStr`
- `FindStr`

```javascript
  fn = fn
    .split('_')
    .map(function(str) {
      return str.charAt(0).toUpperCase() + str.slice(1)
    })
    .join('')
```

The issue is that not all FQL function names come across the wire `in_snake_case`, so the logic above only capitalizes the first letter. Here's an example:

```javascript
// Wire protocol
replacestrregex

// Expected result
ReplaceStrRegex

// Actual result
Replacestrregex
```

### How to test
1. Create a new UDF using one of the functions listed above
2. Save it
3. Confirm the form does not re-case the function name anymore

### Screenshots