### PR TITLE
Fix type of Client.query expression parameter from Expr to ExprArg

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -97,7 +97,7 @@ function Client(options) {
  * Executes a query via the FaunaDB Query API.
  * See the [docs](https://app.fauna.com/documentation/reference/queryapi),
  * and the query functions in this documentation.
- * @param expression {Expr}
+ * @param expression {ExprArg}
  *   The query to execute. Created from query functions such as {@link add}.
  * @param {?Object} options
  *   Object that configures the current query, overriding FaunaDB client options.

--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -1,4 +1,5 @@
 import Expr from './Expr'
+import { ExprArg } from './query'
 import PageHelper from './PageHelper'
 import RequestResult from './RequestResult'
 
@@ -20,7 +21,7 @@ export interface QueryOptions {
 
 export default class Client {
   constructor(opts?: ClientConfig)
-  query<T = object>(expr: Expr, options?: QueryOptions): Promise<T>
+  query<T = object>(expr: ExprArg, options?: QueryOptions): Promise<T>
   paginate(expr: Expr, params?: object, options?: QueryOptions): PageHelper
   ping(scope?: string, timeout?: number): Promise<string>
 }


### PR DESCRIPTION
#268 has surfaced an error within **Client.query** expression parameter type. It is an `Expr` but should in fact be an `ExprArg` as it is converted to an `Expr` within the function itself.

You can find the discussion (30+ msgs) about it here: https://fauna-community.slack.com/archives/CLMPZHJ0G/p1591112108139900.

Wanna add anything to it? @ecwyne @BrunoQuaresma