### PR TITLE
FE-637 | Saving UDFs with Paginate/Match

### DIFF
--- a/src/Expr.js
+++ b/src/Expr.js
@@ -137,6 +137,9 @@ var exprToString = function(expr, caller) {
     if (Array.isArray(terms) && terms.length == 0)
       return 'Match(' + matchStr + ')'
 
+    if (Object.keys(terms).length)
+      return 'Match(' + matchStr + ', ' + printObject(terms) + ')'
+
     return 'Match(' + matchStr + ', ' + printArray(terms, exprToString) + ')'
   }
 


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-637)

**Note:** I am still new to FQL and some of the underlying logic, so extra 👀 on this would be much appreciated 🙏 I'm no longer getting the `Oops...` screen, however, I don't know if I may be creating a new issue. cc: @marrony @evbruno @BrunoQuaresma 

After merging #282 , we received some reports from Community Slack that saving UDFs with `Paginate` or `Match` in them were failing.

From what I can tell, the cause of this was the updated logic inside of `exprToString()` and the ensuing calls to `printArray` and `printObject`. Those functions are named semantically and expect to receive arrays and objects respectively. However, in some cases, the wrong data type was received, which was causing errors.

EX: `.map()` was being called on this object: `{ lowercase: Var("term") }`

### How to test
To test this in the Console, I ran `yarn link` in my local `faundb-js` repo and linked it to my local Console by running `yarn link faunadb` in that folder.

We received these two snippets from one user, both of which were causing the `Oops...` screen upon save.

**Snippet #1**
```
q.Query(
    q.Lambda(
      'terms',
      q.Paginate(
        q.Intersection(
          q.Map(
            q.Var('terms'),
            q.Lambda(
              'term',
              q.Match(q.Index('keywordSearch'), q.LowerCase(q.Var('term')))
            )
          )
        )
      )
    )
  )
```

**Snippet #2**
```
q.Query(
    q.Lambda(
      ['input'],
      q.Select(
        'secret',
        q.Login(
          q.Match(q.Index('unique_User_email'), q.Select('email', q.Var('input'))),
          {
            password: q.Select('password', q.Var('input'))
          }
        )
      )
    )
  )
```