### PR TITLE
FE-630 | Rename Contains to ContainsPath

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var APIVersion = '2.7'
+var APIVersion = '3'
 
 var btoa = require('btoa-lite')
 var errors = require('./errors')

--- a/src/query.js
+++ b/src/query.js
@@ -1950,10 +1950,26 @@ function Equals() {
  * @param {module:query~ExprArg} in
  *   An object to search against.
  * @return {Expr}
+ *
+ * @deprecated use ContainsField instead
  */
 function Contains(path, _in) {
   arity.exact(2, arguments, Contains.name)
   return new Expr({ contains: wrap(path), in: wrap(_in) })
+}
+
+/**
+ * See the [docs](https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions).
+ *
+ * @param {module:query~ExprArg} path
+ *   An array representing a path to check for the existence of.
+ * @param {module:query~ExprArg} in
+ *   An object to search against.
+ * @return {Expr}
+ */
+function ContainsField(path, _in) {
+  arity.exact(2, arguments, ContainsField.name)
+  return new Expr({ contains_field: wrap(path), in: wrap(_in) })
 }
 
 /**
@@ -3087,7 +3103,11 @@ module.exports = {
   Tokens: Tokens,
   Credentials: Credentials,
   Equals: Equals,
-  Contains: Contains,
+  Contains: deprecate(
+    Contains,
+    'Contains() is deprecated, use ContainsField() instead'
+  ),
+  ContainsField: ContainsField,
   Select: Select,
   SelectAll: deprecate(SelectAll, 'SelectAll() is deprecated. Avoid use.'),
   Abs: Abs,

--- a/src/query.js
+++ b/src/query.js
@@ -1951,7 +1951,7 @@ function Equals() {
  *   An object to search against.
  * @return {Expr}
  *
- * @deprecated use ContainsField instead
+ * @deprecated use ContainsPath instead
  */
 function Contains(path, _in) {
   arity.exact(2, arguments, Contains.name)
@@ -1967,9 +1967,9 @@ function Contains(path, _in) {
  *   An object to search against.
  * @return {Expr}
  */
-function ContainsField(path, _in) {
-  arity.exact(2, arguments, ContainsField.name)
-  return new Expr({ contains_field: wrap(path), in: wrap(_in) })
+function ContainsPath(path, _in) {
+  arity.exact(2, arguments, ContainsPath.name)
+  return new Expr({ contains_path: wrap(path), in: wrap(_in) })
 }
 
 /**
@@ -3105,9 +3105,9 @@ module.exports = {
   Equals: Equals,
   Contains: deprecate(
     Contains,
-    'Contains() is deprecated, use ContainsField() instead'
+    'Contains() is deprecated, use ContainsPath() instead'
   ),
-  ContainsField: ContainsField,
+  ContainsPath: ContainsPath,
   Select: Select,
   SelectAll: deprecate(SelectAll, 'SelectAll() is deprecated. Avoid use.'),
   Abs: Abs,

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -256,5 +256,5 @@ export module query {
   export function MoveDatabase(from: ExprArg, to: ExprArg): Expr
   export function Documents(collection: ExprArg): Expr
 
-  export function ContainsField(path: ExprArg, _in: ExprArg): Expr
+  export function ContainsPath(path: ExprArg, _in: ExprArg): Expr
 }

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -255,4 +255,6 @@ export module query {
 
   export function MoveDatabase(from: ExprArg, to: ExprArg): Expr
   export function Documents(collection: ExprArg): Expr
+
+  export function ContainsField(path: ExprArg, _in: ExprArg): Expr
 }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1491,7 +1491,7 @@ describe('query', () => {
     return Promise.all([p1, p2, p3])
   })
 
-  test('contains_field', () => {
+  test('contains_path', () => {
     var obj = { a: { b: 1 } }
     var p1 = assertQuery(query.ContainsPath(['a', 'b'], obj), true)
     var p2 = assertQuery(query.ContainsPath('a', obj), true)

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -396,7 +396,7 @@ describe('query', () => {
     // Works on page too
     var page = query.Paginate(nSet(1))
     var refsWithM = query.Filter(page, function(a) {
-      return query.Contains(['data', 'm'], query.Get(a))
+      return query.ContainsField(['data', 'm'], query.Get(a))
     })
     var p2 = assertQuery(refsWithM, { data: [refN1M1] })
 
@@ -1485,9 +1485,9 @@ describe('query', () => {
 
   test('contains', () => {
     var obj = { a: { b: 1 } }
-    var p1 = assertQuery(query.Contains(['a', 'b'], obj), true)
-    var p2 = assertQuery(query.Contains('a', obj), true)
-    var p3 = assertQuery(query.Contains(['a', 'c'], obj), false)
+    var p1 = assertQuery(query.ContainsField(['a', 'b'], obj), true)
+    var p2 = assertQuery(query.ContainsField('a', obj), true)
+    var p3 = assertQuery(query.ContainsField(['a', 'c'], obj), false)
     return Promise.all([p1, p2, p3])
   })
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -396,7 +396,7 @@ describe('query', () => {
     // Works on page too
     var page = query.Paginate(nSet(1))
     var refsWithM = query.Filter(page, function(a) {
-      return query.ContainsField(['data', 'm'], query.Get(a))
+      return query.ContainsPath(['data', 'm'], query.Get(a))
     })
     var p2 = assertQuery(refsWithM, { data: [refN1M1] })
 
@@ -1493,9 +1493,9 @@ describe('query', () => {
 
   test('contains_field', () => {
     var obj = { a: { b: 1 } }
-    var p1 = assertQuery(query.ContainsField(['a', 'b'], obj), true)
-    var p2 = assertQuery(query.ContainsField('a', obj), true)
-    var p3 = assertQuery(query.ContainsField(['a', 'c'], obj), false)
+    var p1 = assertQuery(query.ContainsPath(['a', 'b'], obj), true)
+    var p2 = assertQuery(query.ContainsPath('a', obj), true)
+    var p3 = assertQuery(query.ContainsPath(['a', 'c'], obj), false)
     return Promise.all([p1, p2, p3])
   })
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1483,7 +1483,7 @@ describe('query', () => {
     return Promise.all([p1, p2, p3, p4])
   })
 
-  test('contains', () => {
+  test('contains_field', () => {
     var obj = { a: { b: 1 } }
     var p1 = assertQuery(query.ContainsField(['a', 'b'], obj), true)
     var p2 = assertQuery(query.ContainsField('a', obj), true)

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1483,6 +1483,14 @@ describe('query', () => {
     return Promise.all([p1, p2, p3, p4])
   })
 
+  test('contains', () => {
+    var obj = { a: { b: 1 } }
+    var p1 = assertQuery(query.Contains(['a', 'b'], obj), true)
+    var p2 = assertQuery(query.Contains('a', obj), true)
+    var p3 = assertQuery(query.Contains(['a', 'c'], obj), false)
+    return Promise.all([p1, p2, p3])
+  })
+
   test('contains_field', () => {
     var obj = { a: { b: 1 } }
     var p1 = assertQuery(query.ContainsField(['a', 'b'], obj), true)

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1914,19 +1914,17 @@ describe('query', () => {
   test('and', () => {
     var p1 = assertQuery(query.And(true, true, false), false)
     var p2 = assertQuery(query.And(true, true, true), true)
-    // var p3 = assertQuery(query.And(true), true)
-    // var p4 = assertQuery(query.And(false), false)
-    // return Promise.all([p1, p2, p3, p4])
-    return Promise.all([p1, p2])
+    var p3 = assertQuery(query.And(true), true)
+    var p4 = assertQuery(query.And(false), false)
+    return Promise.all([p1, p2, p3, p4])
   })
 
   test('or', () => {
     var p1 = assertQuery(query.Or(false, false, true), true)
     var p2 = assertQuery(query.Or(false, false, false), false)
-    // var p3 = assertQuery(query.Or(true), true)
-    // var p4 = assertQuery(query.Or(false), false)
-    // return Promise.all([p1, p2, p3, p4])
-    return Promise.all([p1, p2])
+    var p3 = assertQuery(query.Or(true), true)
+    var p4 = assertQuery(query.Or(false), false)
+    return Promise.all([p1, p2, p3, p4])
   })
 
   test('not', () => {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1914,17 +1914,19 @@ describe('query', () => {
   test('and', () => {
     var p1 = assertQuery(query.And(true, true, false), false)
     var p2 = assertQuery(query.And(true, true, true), true)
-    var p3 = assertQuery(query.And(true), true)
-    var p4 = assertQuery(query.And(false), false)
-    return Promise.all([p1, p2, p3, p4])
+    // var p3 = assertQuery(query.And(true), true)
+    // var p4 = assertQuery(query.And(false), false)
+    // return Promise.all([p1, p2, p3, p4])
+    return Promise.all([p1, p2])
   })
 
   test('or', () => {
     var p1 = assertQuery(query.Or(false, false, true), true)
     var p2 = assertQuery(query.Or(false, false, false), false)
-    var p3 = assertQuery(query.Or(true), true)
-    var p4 = assertQuery(query.Or(false), false)
-    return Promise.all([p1, p2, p3, p4])
+    // var p3 = assertQuery(query.Or(true), true)
+    // var p4 = assertQuery(query.Or(false), false)
+    // return Promise.all([p1, p2, p3, p4])
+    return Promise.all([p1, p2])
   })
 
   test('not', () => {


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-630)

This PR adds a new FQL function called `ContainsPath` as part of API v3. For now, we are deprecating `Contains` and will plan on removing it completely in a future release.