### PR TITLE
FE-652 | Add ContainsField

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var APIVersion = '2.7'
+var APIVersion = '3'
 
 var btoa = require('btoa-lite')
 var errors = require('./errors')

--- a/src/query.js
+++ b/src/query.js
@@ -1978,10 +1978,6 @@ function ContainsField(field, obj) {
     throw new errors.InvalidValue('ContainsField does not accept numbers')
   }
 
-  console.log(
-    'ContainsField',
-    new Expr({ contains_field: wrap(field), in: wrap(obj) })
-  )
   return new Expr({ contains_field: wrap(field), in: wrap(obj) })
 }
 

--- a/src/query.js
+++ b/src/query.js
@@ -1959,6 +1959,35 @@ function Contains(path, _in) {
 /**
  * See the [docs](https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions).
  *
+ * @param {module:query~ExprArg} field
+ *   A value representing a field we want to confirm exists.
+ * @param {module:query~ExprArg} obj
+ *   An object to search against.
+ * @return {Expr}
+ */
+function ContainsField(field, obj) {
+  arity.exact(2, arguments, ContainsField.name)
+
+  if (typeof arguments[0] === 'object') {
+    throw new errors.InvalidValue(
+      'ContainsField does not accept objects or arrays'
+    )
+  }
+
+  if (typeof arguments[0] === 'number') {
+    throw new errors.InvalidValue('ContainsField does not accept numbers')
+  }
+
+  console.log(
+    'ContainsField',
+    new Expr({ contains_field: wrap(field), in: wrap(obj) })
+  )
+  return new Expr({ contains_field: wrap(field), in: wrap(obj) })
+}
+
+/**
+ * See the [docs](https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions).
+ *
  * @param {module:query~ExprArg} path
  *   An array representing a path to pull from an object.
  * @param {module:query~ExprArg} from
@@ -3088,6 +3117,7 @@ module.exports = {
   Credentials: Credentials,
   Equals: Equals,
   Contains: Contains,
+  ContainsField: ContainsField,
   Select: Select,
   SelectAll: deprecate(SelectAll, 'SelectAll() is deprecated. Avoid use.'),
   Abs: Abs,

--- a/src/query.js
+++ b/src/query.js
@@ -1960,7 +1960,7 @@ function Contains(path, _in) {
  * See the [docs](https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions).
  *
  * @param {string} field
- *   A value representing a field we want to confirm exists.
+ *   A field name we want to confirm exists.
  * @param {module:query~ExprArg} obj
  *   An object to search against.
  * @return {Expr}

--- a/src/query.js
+++ b/src/query.js
@@ -1967,17 +1967,6 @@ function Contains(path, _in) {
  */
 function ContainsField(field, obj) {
   arity.exact(2, arguments, ContainsField.name)
-
-  if (typeof arguments[0] === 'object') {
-    throw new errors.InvalidValue(
-      'ContainsField does not accept objects or arrays'
-    )
-  }
-
-  if (typeof arguments[0] === 'number') {
-    throw new errors.InvalidValue('ContainsField does not accept numbers')
-  }
-
   return new Expr({ contains_field: wrap(field), in: wrap(obj) })
 }
 

--- a/src/query.js
+++ b/src/query.js
@@ -1959,7 +1959,7 @@ function Contains(path, _in) {
 /**
  * See the [docs](https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions).
  *
- * @param {String} field
+ * @param {string} field
  *   A value representing a field we want to confirm exists.
  * @param {module:query~ExprArg} obj
  *   An object to search against.

--- a/src/query.js
+++ b/src/query.js
@@ -1959,7 +1959,7 @@ function Contains(path, _in) {
 /**
  * See the [docs](https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions).
  *
- * @param {module:query~ExprArg} field
+ * @param {String} field
  *   A value representing a field we want to confirm exists.
  * @param {module:query~ExprArg} obj
  *   An object to search against.

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -255,5 +255,5 @@ export module query {
 
   export function MoveDatabase(from: ExprArg, to: ExprArg): Expr
   export function Documents(collection: ExprArg): Expr
-  export function ContainsField(path: ExprArg, _in: ExprArg): Expr
+  export function ContainsField(field: string, _in: ExprArg): Expr
 }

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -255,4 +255,5 @@ export module query {
 
   export function MoveDatabase(from: ExprArg, to: ExprArg): Expr
   export function Documents(collection: ExprArg): Expr
+  export function ContainsField(path: ExprArg, _in: ExprArg): Expr
 }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1497,25 +1497,28 @@ describe('query', () => {
     // Handles strings
     var queryOne = assertQuery(query.ContainsField('band', obj), true)
 
+    // Does not find nested fields
+    var queryTwo = assertQuery(query.ContainsField('trey', obj), false)
+
     // Rejects arrays
-    var queryTwo = assertBadQuery(
+    var queryThree = assertBadQuery(
       query.ContainsField(['band'], obj),
       errors.BadRequest
     )
 
     // Rejects objects
-    var queryThree = assertBadQuery(
+    var queryFour = assertBadQuery(
       query.ContainsField({ members: { trey: 'guitar', mike: 'bass' } }, obj),
       errors.BadRequest
     )
 
     // Rejects numbers
-    var queryFour = assertBadQuery(
+    var queryFive = assertBadQuery(
       query.ContainsField(10, obj),
       errors.BadRequest
     )
 
-    return Promise.all([queryOne, queryTwo, queryThree, queryFour])
+    return Promise.all([queryOne, queryTwo, queryThree, queryFour, queryFive])
   })
 
   test('select', () => {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1936,19 +1936,17 @@ describe('query', () => {
   test('and', () => {
     var p1 = assertQuery(query.And(true, true, false), false)
     var p2 = assertQuery(query.And(true, true, true), true)
-    // var p3 = assertQuery(query.And(true), true)
-    // var p4 = assertQuery(query.And(false), false)
-    // return Promise.all([p1, p2, p3, p4])
-    return Promise.all([p1, p2])
+    var p3 = assertQuery(query.And(true), true)
+    var p4 = assertQuery(query.And(false), false)
+    return Promise.all([p1, p2, p3, p4])
   })
 
   test('or', () => {
     var p1 = assertQuery(query.Or(false, false, true), true)
     var p2 = assertQuery(query.Or(false, false, false), false)
-    // var p3 = assertQuery(query.Or(true), true)
-    // var p4 = assertQuery(query.Or(false), false)
-    // return Promise.all([p1, p2, p3, p4])
-    return Promise.all([p1, p2])
+    var p3 = assertQuery(query.Or(true), true)
+    var p4 = assertQuery(query.Or(false), false)
+    return Promise.all([p1, p2, p3, p4])
   })
 
   test('not', () => {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1491,7 +1491,7 @@ describe('query', () => {
     return Promise.all([p1, p2, p3])
   })
 
-  test.only('contains_field', () => {
+  test('contains_field', () => {
     var obj = { band: 'phish', members: { trey: 'guitar', mike: 'bass' } }
 
     // Handles strings

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1491,6 +1491,27 @@ describe('query', () => {
     return Promise.all([p1, p2, p3])
   })
 
+  test('contains_field', () => {
+    var obj = { band: 'phish', members: { trey: 'guitar', mike: 'bass' } }
+
+    // Handles strings
+    var p1 = assertQuery(query.ContainsField('band', obj), true)
+
+    // Rejects arrays
+    var p2 = assertQuery(query.ContainsField(['band'], obj), false)
+
+    // Rejects objects
+    var p3 = assertQuery(
+      query.ContainsField({ members: { trey: 'guitar', mike: 'bass' } }, obj),
+      false
+    )
+
+    // Rejects numbers
+    var p4 = assertQuery(query.ContainsField(10, obj), false)
+
+    return Promise.all([p1, p2, p3, p4])
+  })
+
   test('select', () => {
     var obj = { a: { b: 1 } }
     var p1 = assertQuery(query.Select('a', obj), { b: 1 })

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1491,25 +1491,31 @@ describe('query', () => {
     return Promise.all([p1, p2, p3])
   })
 
-  test('contains_field', () => {
+  test.only('contains_field', () => {
     var obj = { band: 'phish', members: { trey: 'guitar', mike: 'bass' } }
 
     // Handles strings
-    var p1 = assertQuery(query.ContainsField('band', obj), true)
+    var queryOne = assertQuery(query.ContainsField('band', obj), true)
 
     // Rejects arrays
-    var p2 = assertQuery(query.ContainsField(['band'], obj), false)
+    var queryTwo = assertBadQuery(
+      query.ContainsField(['band'], obj),
+      errors.BadRequest
+    )
 
     // Rejects objects
-    var p3 = assertQuery(
+    var queryThree = assertBadQuery(
       query.ContainsField({ members: { trey: 'guitar', mike: 'bass' } }, obj),
-      false
+      errors.BadRequest
     )
 
     // Rejects numbers
-    var p4 = assertQuery(query.ContainsField(10, obj), false)
+    var queryFour = assertBadQuery(
+      query.ContainsField(10, obj),
+      errors.BadRequest
+    )
 
-    return Promise.all([p1, p2, p3, p4])
+    return Promise.all([queryOne, queryTwo, queryThree, queryFour])
   })
 
   test('select', () => {
@@ -1927,17 +1933,19 @@ describe('query', () => {
   test('and', () => {
     var p1 = assertQuery(query.And(true, true, false), false)
     var p2 = assertQuery(query.And(true, true, true), true)
-    var p3 = assertQuery(query.And(true), true)
-    var p4 = assertQuery(query.And(false), false)
-    return Promise.all([p1, p2, p3, p4])
+    // var p3 = assertQuery(query.And(true), true)
+    // var p4 = assertQuery(query.And(false), false)
+    // return Promise.all([p1, p2, p3, p4])
+    return Promise.all([p1, p2])
   })
 
   test('or', () => {
     var p1 = assertQuery(query.Or(false, false, true), true)
     var p2 = assertQuery(query.Or(false, false, false), false)
-    var p3 = assertQuery(query.Or(true), true)
-    var p4 = assertQuery(query.Or(false), false)
-    return Promise.all([p1, p2, p3, p4])
+    // var p3 = assertQuery(query.Or(true), true)
+    // var p4 = assertQuery(query.Or(false), false)
+    // return Promise.all([p1, p2, p3, p4])
+    return Promise.all([p1, p2])
   })
 
   test('not', () => {


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-652)

This PR adds the `ContainsField` function to our JavaScript driver. I have also included some test coverage that reflects how the [functionality is defined within Core](https://github.com/fauna/core/blob/09784957af4b33f597761ac768283f7a8eb6edbf/ext/api/src/test/scala/queries/BasicFunctionsSpec.scala#L1214).

The function takes two arguments:
1. A string representing the field to search for (rejects arrays, objects and numbers)
2. An object which we'll search its root for the field value 