### PR TITLE
FE-654 | Fix driver tests due to core updates

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var APIVersion = '2.7'
+var APIVersion = '3'
 
 var btoa = require('btoa-lite')
 var errors = require('./errors')

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1906,17 +1906,13 @@ describe('query', () => {
   test('and', () => {
     var p1 = assertQuery(query.And(true, true, false), false)
     var p2 = assertQuery(query.And(true, true, true), true)
-    var p3 = assertQuery(query.And(true), true)
-    var p4 = assertQuery(query.And(false), false)
-    return Promise.all([p1, p2, p3, p4])
+    return Promise.all([p1, p2])
   })
 
   test('or', () => {
     var p1 = assertQuery(query.Or(false, false, true), true)
     var p2 = assertQuery(query.Or(false, false, false), false)
-    var p3 = assertQuery(query.Or(true), true)
-    var p4 = assertQuery(query.Or(false), false)
-    return Promise.all([p1, p2, p3, p4])
+    return Promise.all([p1, p2])
   })
 
   test('not', () => {


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-654)

Our driver tests were failing due to some [updates in the Core](https://github.com/fauna/core/pull/6785/files). This PR is intended to fix those issues, so we can more easily/accurately test the work in #292 ad #294 

**Note:** 
1. These tests will pass when the API version header is set to `2.7`, but in order to test the work linked in the PRs above, we need to be using `3`. 
2. Once [this PR](https://github.com/fauna/core/pull/6776) makes it into our nightly build, this PR will pass with API v`3`
3. Once [this PR](https://github.com/fauna/core/pull/6785) is merged, we can add back these tests for single arguments