### PR TITLE
Revert "FE-625: Fix Paginate/Match rendering"

### DIFF
--- a/src/Expr.js
+++ b/src/Expr.js
@@ -75,12 +75,12 @@ var specialCases = {
 }
 
 var exprToString = function(expr, caller) {
-  var isExpr = function(e) {
-    return e instanceof Expr || util.checkInstanceHasProperty(e, '_isFaunaExpr')
-  }
-
-  if (isExpr(expr)) {
+  if (
+    expr instanceof Expr ||
+    util.checkInstanceHasProperty(expr, '_isFaunaExpr')
+  ) {
     if ('value' in expr) return expr.toString()
+
     expr = expr.raw
   }
 
@@ -126,29 +126,6 @@ var exprToString = function(expr, caller) {
     var array = printArray(expr, exprToString)
 
     return varArgsFunctions.indexOf(caller) != -1 ? array : '[' + array + ']'
-  }
-
-  if ('match' in expr) {
-    var matchStr = exprToString(expr['match'])
-    var terms = expr['terms'] || []
-
-    if (isExpr(terms)) terms = terms.raw
-
-    if (Array.isArray(terms) && terms.length == 0)
-      return 'Match(' + matchStr + ')'
-
-    return 'Match(' + matchStr + ', ' + printArray(terms, exprToString) + ')'
-  }
-
-  if ('paginate' in expr) {
-    var setStr = exprToString(expr['paginate'])
-
-    var expr2 = Object.assign({}, expr)
-    delete expr2['paginate']
-
-    if (Object.keys(expr2).length == 0) return 'Paginate(' + setStr + ')'
-
-    return 'Paginate(' + setStr + ', ' + printObject(expr2) + ')'
   }
 
   if ('let' in expr && 'in' in expr) {

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -242,32 +242,6 @@ describe('Values', () => {
     )
   })
 
-  test('pretty print Match', () => {
-    assertPrint(
-      new Query(q.Lambda('_', q.Match(q.Index('idx')))),
-      'Query(Lambda("_", Match(Index("idx"))))'
-    )
-
-    assertPrint(
-      new Query(q.Lambda('_', q.Match(q.Index('idx'), 'str', 10))),
-      'Query(Lambda("_", Match(Index("idx"), "str", 10)))'
-    )
-  })
-
-  test('pretty print Paginate', () => {
-    var m = q.Match(q.Index('idx'))
-
-    assertPrint(
-      new Query(q.Lambda('_', q.Paginate(m))),
-      'Query(Lambda("_", Paginate(Match(Index("idx")))))'
-    )
-
-    assertPrint(
-      new Query(q.Lambda('_', q.Paginate(m, { size: 10, after: [20] }))),
-      'Query(Lambda("_", Paginate(Match(Index("idx")), {size: 10, after: [20]})))'
-    )
-  })
-
   test('pretty print Query', () => {
     assertPrint(
       new Query(q.Lambda('x', q.Var('x'))),


### PR DESCRIPTION
This reverts commit 5b6fa91cb53ffa82d2625314b625a947fa15d776.

### Notes
This PR reverts [a previous PR](https://github.com/fauna/faunadb-js/pull/282/) which is causing errors with `Paginate` and `Match`, particularly in UDFs. I also experienced the same error when running unit tests while working on adding API v3 functions.

We are reverting this change for now because it is blocking our releases.