### PR TITLE
FE-665 | Add AccessProvider document type and tests

### DIFF
--- a/src/_json.js
+++ b/src/_json.js
@@ -21,6 +21,17 @@ function json_parse(_, val) {
     return val
   } else if ('@ref' in val) {
     var ref = val['@ref']
+    var isAccessProvider = ref.name && ref.issuer && ref.jwks_url
+
+    if (isAccessProvider) {
+      return new values.AccessProvider(
+        ref.name,
+        ref.issuer,
+        ref.jwks_url,
+        ref.allowed_roles,
+        ref.allowed_collections
+      )
+    }
 
     if (!('collection' in ref) && !('database' in ref)) {
       return values.Native.fromName(ref['id'])
@@ -42,15 +53,6 @@ function json_parse(_, val) {
     return new values.Bytes(val['@bytes'])
   } else if ('@query' in val) {
     return new values.Query(val['@query'])
-  } else if ('@access_provider' in val) {
-    var ref = val['@access_provider']
-    return new values.AccessProvider(
-      ref.name,
-      ref.issuer,
-      ref.jwks_url,
-      ref.allowed_roles,
-      ref.allowed_collections
-    )
   } else {
     return val
   }

--- a/src/_json.js
+++ b/src/_json.js
@@ -42,6 +42,15 @@ function json_parse(_, val) {
     return new values.Bytes(val['@bytes'])
   } else if ('@query' in val) {
     return new values.Query(val['@query'])
+  } else if ('@access_provider' in val) {
+    var ref = val['@access_provider']
+    return new values.AccessProvider(
+      ref.name,
+      ref.issuer,
+      ref.jwks_url,
+      ref.allowed_roles,
+      ref.allowed_collections
+    )
   } else {
     return val
   }

--- a/src/_json.js
+++ b/src/_json.js
@@ -21,17 +21,6 @@ function json_parse(_, val) {
     return val
   } else if ('@ref' in val) {
     var ref = val['@ref']
-    var isAccessProvider = ref.name && ref.issuer && ref.jwks_url
-
-    if (isAccessProvider) {
-      return new values.AccessProvider(
-        ref.name,
-        ref.issuer,
-        ref.jwks_url,
-        ref.allowed_roles,
-        ref.allowed_collections
-      )
-    }
 
     if (!('collection' in ref) && !('database' in ref)) {
       return values.Native.fromName(ref['id'])

--- a/src/types/values.d.ts
+++ b/src/types/values.d.ts
@@ -55,6 +55,16 @@ export module values {
     constructor(value: object)
   }
 
+  export class AccessProvider {
+    constructor(
+      name: string,
+      issuer: string,
+      jwks_url: string,
+      allowed_roles?: Array<Ref>,
+      allowed_collections?: Array<Ref>
+    )
+  }
+
   export type Document<T = object> = {
     ref: Ref
     ts: number

--- a/src/types/values.d.ts
+++ b/src/types/values.d.ts
@@ -25,6 +25,7 @@ export module values {
     static readonly DATABASES: Ref
     static readonly KEYS: Ref
     static readonly FUNCTIONS: Ref
+    static readonly ACCESS_PROVIDERS: Ref
   }
 
   export class SetRef extends Value {

--- a/src/types/values.d.ts
+++ b/src/types/values.d.ts
@@ -55,7 +55,7 @@ export module values {
     constructor(value: object)
   }
 
-  export class AccessProvider {
+  export class AccessProvider extends Value {
     constructor(
       name: string,
       issuer: string,
@@ -63,6 +63,12 @@ export module values {
       allowed_roles?: Array<Ref>,
       allowed_collections?: Array<Ref>
     )
+
+    name: string
+    issuer: string
+    jwks_url: string
+    allowed_roles?: Array<Ref>
+    allowed_collections?: Array<Ref>
   }
 
   export type Document<T = object> = {

--- a/src/types/values.d.ts
+++ b/src/types/values.d.ts
@@ -55,22 +55,6 @@ export module values {
     constructor(value: object)
   }
 
-  export class AccessProvider extends Value {
-    constructor(
-      name: string,
-      issuer: string,
-      jwks_url: string,
-      allowed_roles?: Array<Ref>,
-      allowed_collections?: Array<Ref>
-    )
-
-    name: string
-    issuer: string
-    jwks_url: string
-    allowed_roles?: Array<Ref>
-    allowed_collections?: Array<Ref>
-  }
-
   export type Document<T = object> = {
     ref: Ref
     ts: number

--- a/src/values.js
+++ b/src/values.js
@@ -381,28 +381,34 @@ function AccessProvider(
   allowed_roles,
   allowed_collections
 ) {
-  this.name = name
-  this.issuer = issuer
-  this.jwks_url = jwks_url
-  this.allowed_roles = []
-  this.allowed_collections = []
-
   if (!name || !issuer || !jwks_url) {
     throw new errors.InvalidValue(
       'AccessProvider requires a name, issuer and jwks_url'
     )
   }
 
+  this.value = {
+    name: name,
+    issuer: issuer,
+    jwks_url: jwks_url,
+    allowed_roles: [],
+    allowed_collections: [],
+  }
+
   if (allowed_roles) {
-    this.allowed_roles = allowed_roles
+    this.value.allowed_roles = allowed_roles
   }
 
   if (allowed_collections) {
-    this.allowed_collections = allowed_collections
+    this.value.allowed_collections = allowed_collections
   }
 }
 
 util.inherits(AccessProvider, Value)
+
+AccessProvider.prototype.toJSON = function() {
+  return { '@access_provider': this.value }
+}
 
 module.exports = {
   Value: Value,

--- a/src/values.js
+++ b/src/values.js
@@ -123,12 +123,15 @@ wrapToString(Ref, function() {
     indexes: 'Index',
     functions: 'Function',
     roles: 'Role',
-    accessProviders: 'AccessProvider',
+    access_providers: 'AccessProvider',
   }
 
   var toString = function(ref) {
     if (ref.collection === undefined) {
       var db = ref.database !== undefined ? ref.database.toString() : ''
+
+      if (ref.id === 'access_providers') return 'AccessProviders(' + db + ')'
+
       return ref.id.charAt(0).toUpperCase() + ref.id.slice(1) + '(' + db + ')'
     }
 
@@ -173,7 +176,7 @@ var Native = {
   FUNCTIONS: new Ref('functions'),
   ROLES: new Ref('roles'),
   KEYS: new Ref('keys'),
-  ACCESS_PROVIDERS: new Ref('accessProviders'),
+  ACCESS_PROVIDERS: new Ref('access_providers'),
 }
 
 Native.fromName = function(name) {
@@ -190,7 +193,7 @@ Native.fromName = function(name) {
       return Native.ROLES
     case 'keys':
       return Native.KEYS
-    case 'accessProviders':
+    case 'access_providers':
       return Native.ACCESS_PROVIDERS
   }
   return new Ref(name)

--- a/src/values.js
+++ b/src/values.js
@@ -365,11 +365,11 @@ function wrapToString(type, fn) {
 }
 
 /**
- * @param {string} name
- * @param {string} issuer
- * @param {string} jwks_url
- * @param {Array<Ref>} [allowed_roles] allowed_roles
- * @param {Array<Ref>} [allowed_collections] allowed_collections
+ * @param {string} name A valid schema name
+ * @param {string} issuer A unique string
+ * @param {string} jwks_url A valid HTTPS URL
+ * @param {Array<Ref>} [allowed_roles] A list of Role refs
+ * @param {Array<Ref>} [allowed_collections] A list of user-defined Collection refs
  *
  * @extends module:values~Value
  * @constructor

--- a/src/values.js
+++ b/src/values.js
@@ -364,6 +364,16 @@ function wrapToString(type, fn) {
   }
 }
 
+/**
+ * @param {string} name
+ * @param {string} issuer
+ * @param {string} jwks_url
+ * @param {Array<Ref>} [allowed_roles] allowed_roles
+ * @param {Array<Ref>} [allowed_collections] allowed_collections
+ *
+ * @extends module:values~Value
+ * @constructor
+ */
 function AccessProvider(
   name,
   issuer,
@@ -389,6 +399,8 @@ function AccessProvider(
     this.allowed_collections = allowed_collections
   }
 }
+
+util.inherits(AccessProvider, Value)
 
 module.exports = {
   Value: Value,

--- a/src/values.js
+++ b/src/values.js
@@ -364,6 +364,32 @@ function wrapToString(type, fn) {
   }
 }
 
+function AccessProvider(
+  name,
+  issuer,
+  jwks_url,
+  allowed_roles,
+  allowed_collections
+) {
+  this.name = name
+  this.issuer = issuer
+  this.jwks_url = jwks_url
+
+  if (!name || !issuer || !jwks_url) {
+    throw new errors.InvalidValue(
+      'AccessProvider requires a name, issuer and jwks_url'
+    )
+  }
+
+  if (allowed_roles) {
+    this.allowed_roles = allowed_roles
+  }
+
+  if (allowed_collections) {
+    this.allowed_collections = allowed_collections
+  }
+}
+
 module.exports = {
   Value: Value,
   Ref: Ref,
@@ -373,4 +399,5 @@ module.exports = {
   FaunaDate: FaunaDate,
   Bytes: Bytes,
   Query: Query,
+  AccessProvider: AccessProvider,
 }

--- a/src/values.js
+++ b/src/values.js
@@ -407,7 +407,7 @@ function AccessProvider(
 util.inherits(AccessProvider, Value)
 
 AccessProvider.prototype.toJSON = function() {
-  return { '@access_provider': this.value }
+  return { '@ref': this.value }
 }
 
 module.exports = {

--- a/src/values.js
+++ b/src/values.js
@@ -172,6 +172,7 @@ var Native = {
   FUNCTIONS: new Ref('functions'),
   ROLES: new Ref('roles'),
   KEYS: new Ref('keys'),
+  ACCESS_PROVIDERS: new Ref('access_providers'),
 }
 
 Native.fromName = function(name) {
@@ -188,6 +189,8 @@ Native.fromName = function(name) {
       return Native.ROLES
     case 'keys':
       return Native.KEYS
+    case 'access_providers':
+      return Native.ACCESS_PROVIDERS
   }
   return new Ref(name)
 }
@@ -364,52 +367,6 @@ function wrapToString(type, fn) {
   }
 }
 
-/**
- * @param {string} name A valid schema name
- * @param {string} issuer A unique string
- * @param {string} jwks_url A valid HTTPS URL
- * @param {Array<Ref>} [allowed_roles=[]] A list of Role refs
- * @param {Array<Ref>} [allowed_collections=[]] A list of user-defined Collection refs
- *
- * @extends module:values~Value
- * @constructor
- */
-function AccessProvider(
-  name,
-  issuer,
-  jwks_url,
-  allowed_roles,
-  allowed_collections
-) {
-  if (!name || !issuer || !jwks_url) {
-    throw new errors.InvalidValue(
-      'AccessProvider requires a name, issuer and jwks_url'
-    )
-  }
-
-  this.value = {
-    name: name,
-    issuer: issuer,
-    jwks_url: jwks_url,
-    allowed_roles: [],
-    allowed_collections: [],
-  }
-
-  if (allowed_roles) {
-    this.value.allowed_roles = allowed_roles
-  }
-
-  if (allowed_collections) {
-    this.value.allowed_collections = allowed_collections
-  }
-}
-
-util.inherits(AccessProvider, Value)
-
-AccessProvider.prototype.toJSON = function() {
-  return { '@ref': this.value }
-}
-
 module.exports = {
   Value: Value,
   Ref: Ref,
@@ -419,5 +376,4 @@ module.exports = {
   FaunaDate: FaunaDate,
   Bytes: Bytes,
   Query: Query,
-  AccessProvider: AccessProvider,
 }

--- a/src/values.js
+++ b/src/values.js
@@ -123,6 +123,7 @@ wrapToString(Ref, function() {
     indexes: 'Index',
     functions: 'Function',
     roles: 'Role',
+    accessProviders: 'AccessProvider',
   }
 
   var toString = function(ref) {
@@ -172,7 +173,7 @@ var Native = {
   FUNCTIONS: new Ref('functions'),
   ROLES: new Ref('roles'),
   KEYS: new Ref('keys'),
-  ACCESS_PROVIDERS: new Ref('access_providers'),
+  ACCESS_PROVIDERS: new Ref('accessProviders'),
 }
 
 Native.fromName = function(name) {
@@ -189,7 +190,7 @@ Native.fromName = function(name) {
       return Native.ROLES
     case 'keys':
       return Native.KEYS
-    case 'access_providers':
+    case 'accessProviders':
       return Native.ACCESS_PROVIDERS
   }
   return new Ref(name)

--- a/src/values.js
+++ b/src/values.js
@@ -368,8 +368,8 @@ function wrapToString(type, fn) {
  * @param {string} name A valid schema name
  * @param {string} issuer A unique string
  * @param {string} jwks_url A valid HTTPS URL
- * @param {Array<Ref>} [allowed_roles] A list of Role refs
- * @param {Array<Ref>} [allowed_collections] A list of user-defined Collection refs
+ * @param {Array<Ref>} [allowed_roles=[]] A list of Role refs
+ * @param {Array<Ref>} [allowed_collections=[]] A list of user-defined Collection refs
  *
  * @extends module:values~Value
  * @constructor
@@ -384,6 +384,8 @@ function AccessProvider(
   this.name = name
   this.issuer = issuer
   this.jwks_url = jwks_url
+  this.allowed_roles = []
+  this.allowed_collections = []
 
   if (!name || !issuer || !jwks_url) {
     throw new errors.InvalidValue(

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2393,7 +2393,7 @@ describe('query', () => {
     expect(results.data).toHaveLength(20)
   })
 
-  test.only('reverse', async () => {
+  test('reverse', async () => {
     // Array
     const numArray = [1, 2, 3]
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2463,6 +2463,11 @@ describe('query', () => {
     expect(multiPage.data).toEqual(reverseMultiPage.data.reverse())
   })
 
+  test('access_provider', async () => {
+    // TODO: Add tests for AccessProvider here once we add
+    // CreateAccessProvider functionality for API v3
+  })
+
   // Check arity of all query functions
 
   test('arity', () => {

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -143,13 +143,17 @@ describe('Values', () => {
     expect(expected).toEqual(value.toString())
   }
 
-  test('pretty print', () => {
+  test.only('pretty print', () => {
     assertPrint(new Ref('col', values.Native.COLLECTIONS), 'Collection("col")')
     assertPrint(new Ref('db', values.Native.DATABASES), 'Database("db")')
     assertPrint(new Ref('idx', values.Native.INDEXES), 'Index("idx")')
     assertPrint(new Ref('fn', values.Native.FUNCTIONS), 'Function("fn")')
     assertPrint(new Ref('role', values.Native.ROLES), 'Role("role")')
     assertPrint(new Ref('key', values.Native.KEYS), 'Ref(Keys(), "key")')
+    assertPrint(
+      new Ref('accessProvider', values.Native.ACCESS_PROVIDERS),
+      'AccessProvider("accessProvider")'
+    )
 
     assertPrint(values.Native.COLLECTIONS, 'Collections()')
     assertPrint(values.Native.DATABASES, 'Databases()')
@@ -157,6 +161,7 @@ describe('Values', () => {
     assertPrint(values.Native.FUNCTIONS, 'Functions()')
     assertPrint(values.Native.ROLES, 'Roles()')
     assertPrint(values.Native.KEYS, 'Keys()')
+    assertPrint(values.Native.ACCESS_PROVIDERS, 'AccessProviders()')
 
     var db = new Ref('db', values.Native.DATABASES)
 
@@ -166,6 +171,10 @@ describe('Values', () => {
     assertPrint(new Ref('functions', null, db), 'Functions(Database("db"))')
     assertPrint(new Ref('roles', null, db), 'Roles(Database("db"))')
     assertPrint(new Ref('keys', null, db), 'Keys(Database("db"))')
+    assertPrint(
+      new Ref('accessProviders', null, db),
+      'AccessProviders(Database("db"))'
+    )
 
     assertPrint(
       new Ref('col', values.Native.COLLECTIONS, db),
@@ -186,6 +195,10 @@ describe('Values', () => {
     assertPrint(
       new Ref('role', values.Native.ROLES, db),
       'Role("role", Database("db"))'
+    )
+    assertPrint(
+      new Ref('accessProvider', values.Native.ACCESS_PROVIDERS, db),
+      'AccessProvider("accessProvider", Database("db"))'
     )
 
     assertPrint(

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -143,7 +143,7 @@ describe('Values', () => {
     expect(expected).toEqual(value.toString())
   }
 
-  test.only('pretty print', () => {
+  test('pretty print', () => {
     assertPrint(new Ref('col', values.Native.COLLECTIONS), 'Collection("col")')
     assertPrint(new Ref('db', values.Native.DATABASES), 'Database("db")')
     assertPrint(new Ref('idx', values.Native.INDEXES), 'Index("idx")')

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -145,7 +145,7 @@ describe('Values', () => {
     const jwksUrl = 'https://www.fauna.com'
     const provider = new AccessProvider(providerName, issuer, jwksUrl)
     const provider_json =
-      '{"@access_provider":{"name":"my-provider","issuer":"admin","jwks_url":"https://www.fauna.com","allowed_roles":[],"allowed_collections":[]}}'
+      '{"@ref":{"name":"my-provider","issuer":"admin","jwks_url":"https://www.fauna.com","allowed_roles":[],"allowed_collections":[]}}'
 
     // Properly instantiates a new AccessProvider
     expect(provider.value.name).toEqual(providerName)

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -139,26 +139,6 @@ describe('Values', () => {
     expect(json.parseJSON(test_query_json)).toEqual(test_query)
   })
 
-  test('AccessProvider', () => {
-    const providerName = 'my-provider'
-    const issuer = 'admin'
-    const jwksUrl = 'https://www.fauna.com'
-    const provider = new AccessProvider(providerName, issuer, jwksUrl)
-    const provider_json =
-      '{"@ref":{"name":"my-provider","issuer":"admin","jwks_url":"https://www.fauna.com","allowed_roles":[],"allowed_collections":[]}}'
-
-    // Properly instantiates a new AccessProvider
-    expect(provider.value.name).toEqual(providerName)
-    expect(provider.value.issuer).toEqual(issuer)
-    expect(provider.value.jwks_url).toEqual(jwksUrl)
-    expect(provider.value.allowed_roles).toEqual([])
-    expect(provider.value.allowed_collections).toEqual([])
-
-    // Properly parses JSON
-    expect(json.toJSON(provider)).toEqual(provider_json)
-    expect(json.parseJSON(provider_json)).toEqual(provider)
-  })
-
   var assertPrint = function(value, expected) {
     expect(expected).toEqual(util.inspect(value, { depth: null }))
     expect(expected).toEqual(value.toString())

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -12,7 +12,8 @@ var FaunaDate = values.FaunaDate,
   Ref = values.Ref,
   SetRef = values.SetRef,
   Bytes = values.Bytes,
-  Query = values.Query
+  Query = values.Query,
+  AccessProvider = values.AccessProvider
 
 describe('Values', () => {
   var ref = new Ref('123', new Ref('frogs', values.Native.COLLECTIONS)),
@@ -136,6 +137,19 @@ describe('Values', () => {
     var test_query_json = '{"@query":{"lambda":"x","expr":{"var":"x"}}}'
     expect(json.toJSON(test_query)).toEqual(test_query_json)
     expect(json.parseJSON(test_query_json)).toEqual(test_query)
+  })
+
+  test.only('AccessProvider', () => {
+    const providerName = 'my-provider'
+    const issuer = 'admin'
+    const jwksUrl = 'https://www.fauna.com'
+    const provider = new AccessProvider(providerName, issuer, jwksUrl)
+
+    expect(provider.name).toEqual(providerName)
+    expect(provider.issuer).toEqual(issuer)
+    expect(provider.jwks_url).toEqual(jwksUrl)
+    expect(provider.allowed_roles).toEqual([])
+    expect(provider.allowed_collections).toEqual([])
   })
 
   var assertPrint = function(value, expected) {

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -12,8 +12,7 @@ var FaunaDate = values.FaunaDate,
   Ref = values.Ref,
   SetRef = values.SetRef,
   Bytes = values.Bytes,
-  Query = values.Query,
-  AccessProvider = values.AccessProvider
+  Query = values.Query
 
 describe('Values', () => {
   var ref = new Ref('123', new Ref('frogs', values.Native.COLLECTIONS)),

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -139,17 +139,24 @@ describe('Values', () => {
     expect(json.parseJSON(test_query_json)).toEqual(test_query)
   })
 
-  test.only('AccessProvider', () => {
+  test('AccessProvider', () => {
     const providerName = 'my-provider'
     const issuer = 'admin'
     const jwksUrl = 'https://www.fauna.com'
     const provider = new AccessProvider(providerName, issuer, jwksUrl)
+    const provider_json =
+      '{"@access_provider":{"name":"my-provider","issuer":"admin","jwks_url":"https://www.fauna.com","allowed_roles":[],"allowed_collections":[]}}'
 
-    expect(provider.name).toEqual(providerName)
-    expect(provider.issuer).toEqual(issuer)
-    expect(provider.jwks_url).toEqual(jwksUrl)
-    expect(provider.allowed_roles).toEqual([])
-    expect(provider.allowed_collections).toEqual([])
+    // Properly instantiates a new AccessProvider
+    expect(provider.value.name).toEqual(providerName)
+    expect(provider.value.issuer).toEqual(issuer)
+    expect(provider.value.jwks_url).toEqual(jwksUrl)
+    expect(provider.value.allowed_roles).toEqual([])
+    expect(provider.value.allowed_collections).toEqual([])
+
+    // Properly parses JSON
+    expect(json.toJSON(provider)).toEqual(provider_json)
+    expect(json.parseJSON(provider_json)).toEqual(provider)
   })
 
   var assertPrint = function(value, expected) {

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -151,8 +151,8 @@ describe('Values', () => {
     assertPrint(new Ref('role', values.Native.ROLES), 'Role("role")')
     assertPrint(new Ref('key', values.Native.KEYS), 'Ref(Keys(), "key")')
     assertPrint(
-      new Ref('accessProvider', values.Native.ACCESS_PROVIDERS),
-      'AccessProvider("accessProvider")'
+      new Ref('access_provider', values.Native.ACCESS_PROVIDERS),
+      'AccessProvider("access_provider")'
     )
 
     assertPrint(values.Native.COLLECTIONS, 'Collections()')
@@ -172,7 +172,7 @@ describe('Values', () => {
     assertPrint(new Ref('roles', null, db), 'Roles(Database("db"))')
     assertPrint(new Ref('keys', null, db), 'Keys(Database("db"))')
     assertPrint(
-      new Ref('accessProviders', null, db),
+      new Ref('access_providers', null, db),
       'AccessProviders(Database("db"))'
     )
 
@@ -197,8 +197,8 @@ describe('Values', () => {
       'Role("role", Database("db"))'
     )
     assertPrint(
-      new Ref('accessProvider', values.Native.ACCESS_PROVIDERS, db),
-      'AccessProvider("accessProvider", Database("db"))'
+      new Ref('access_provider', values.Native.ACCESS_PROVIDERS, db),
+      'AccessProvider("access_provider", Database("db"))'
     )
 
     assertPrint(


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-665)

**Additional specs:** https://faunadb.atlassian.net/browse/ENG-1941

This PR does the following:
1. Adds a `AccessProvider` document type
2. Adds definition of `AccessProvider` to TS types file
3. Implements logic for JSON parsing
4. Adds tests to cover instantiation and JSON parsing/encoding of `AccessProvider`

### How to test
Run our local test suite: `npm run test`