### PR TITLE
FE-663 | Add CreateAccessProvider function

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -1024,6 +1024,23 @@ function CreateRole(params) {
   return new Expr({ create_role: wrap(params) })
 }
 
+/**
+ * See the [docs](https://app.fauna.com/documentation/reference/queryapi#write-functions).
+ *
+ * @param {module:query~ExprArg} params
+ *   An object of parameters used to create a new access provider.
+ *     - name: A valid schema name
+ *     - issuer: A unique string
+ *     - jwks_url: A valid HTTPS URL
+ *     - allowed_roles: An optional list of Role refs
+ *     - allowed_collections: An optional list of user-defined Collection refs
+ * @return {Expr}
+ */
+function CreateAccessProvider(params) {
+  arity.exact(1, arguments, CreateAccessProvider.name)
+  return new Expr({ create_access_provider: wrap(params) })
+}
+
 // Sets
 
 /**
@@ -3074,6 +3091,7 @@ module.exports = {
   CreateKey: CreateKey,
   CreateFunction: CreateFunction,
   CreateRole: CreateRole,
+  CreateAccessProvider: CreateAccessProvider,
   Singleton: Singleton,
   Events: Events,
   Match: Match,

--- a/src/query.js
+++ b/src/query.js
@@ -1031,7 +1031,7 @@ function CreateRole(params) {
  *   An object of parameters used to create a new access provider.
  *     - name: A valid schema name
  *     - issuer: A unique string
- *     - jwks_url: A valid HTTPS URL
+ *     - jwks_uri: A valid HTTPS URI
  *     - allowed_roles: An optional list of Role refs
  *     - allowed_collections: An optional list of user-defined Collection refs
  * @return {Expr}

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -94,6 +94,7 @@ export module query {
   export function CreateKey(params: ExprArg): Expr
   export function CreateFunction(params: ExprArg): Expr
   export function CreateRole(params: ExprArg): Expr
+  export function CreateAccessProvider(params: ExprArg): Expr
 
   export function Singleton(ref: ExprArg): Expr
   export function Events(ref_set: ExprArg): Expr

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -848,6 +848,18 @@ describe('query', () => {
     })
   })
 
+  test.only('create access provider', async () => {
+    const provider = await adminClient.query(
+      query.CreateAccessProvider({
+        name: 'my_provider',
+        issuer: 'user-123',
+        jwks_url: 'https://db.fauna.com',
+      })
+    )
+
+    console.log(provider)
+  })
+
   // Sets
 
   test('events', () => {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -848,16 +848,63 @@ describe('query', () => {
     })
   })
 
-  test.only('create access provider', async () => {
+  test('create access provider', async () => {
+    const providerName = util.randomString('provider_')
+    const issuerName = util.randomString('issuer_')
+    const jwksUri = util.randomString()
+    const fullUri = `https://${jwksUri}.com`
+
+    // Successful instantiation with required fields
     const provider = await adminClient.query(
       query.CreateAccessProvider({
-        name: 'my_provider',
-        issuer: 'user-123',
-        jwks_url: 'https://db.fauna.com',
+        name: providerName,
+        issuer: issuerName,
+        jwks_uri: fullUri,
       })
     )
 
-    console.log(provider)
+    expect(provider.name).toEqual(providerName)
+    expect(provider.issuer).toEqual(issuerName)
+    expect(provider.jwks_uri).toEqual(fullUri)
+
+    // Failure due to missing name
+    try {
+      await adminClient.query(
+        query.CreateAccessProvider({
+          name: null,
+          issuer: issuerName,
+          jwks_uri: fullUri,
+        })
+      )
+    } catch (error) {
+      expect(error).toBeInstanceOf(errors.BadRequest)
+    }
+
+    // Failure due to missing issuer
+    try {
+      await adminClient.query(
+        query.CreateAccessProvider({
+          name: providerName,
+          issuer: null,
+          jwks_uri: fullUri,
+        })
+      )
+    } catch (error) {
+      expect(error).toBeInstanceOf(errors.BadRequest)
+    }
+
+    // Failure due to invalid URI
+    try {
+      await adminClient.query(
+        query.CreateAccessProvider({
+          name: providerName,
+          issuer: issuerName,
+          jwks_uri: jwksUri,
+        })
+      )
+    } catch (error) {
+      expect(error).toBeInstanceOf(errors.BadRequest)
+    }
   })
 
   // Sets

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -867,6 +867,19 @@ describe('query', () => {
     expect(provider.issuer).toEqual(issuerName)
     expect(provider.jwks_uri).toEqual(fullUri)
 
+    // Failure due to non-unique issuer
+    try {
+      await adminClient.query(
+        query.CreateAccessProvider({
+          name: 'duplicate_provider',
+          issuer: issuerName,
+          jwks_uri: 'https://db.fauna.com',
+        })
+      )
+    } catch (error) {
+      expect(error).toBeInstanceOf(errors.BadRequest)
+    }
+
     // Failure due to missing name
     try {
       await adminClient.query(


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-663)
**Additional specs:** https://faunadb.atlassian.net/browse/DRV-124

This PR adds the `CreateAccessProvider` function 👍 

### How to test
~Tests currently won't pass. I [need to get clarification re: how to test this function ](https://github.com/fauna/faunadb-js/pull/300#pullrequestreview-434210888)or remove the `create_access_provider` test block in `query.test.js`~

Run `npm run test`