### PR TITLE
FE-669 | Add AccessProvider function

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -2889,6 +2889,17 @@ function Reverse(expr) {
   return new Expr({ reverse: wrap(expr) })
 }
 
+/**
+ *
+ * @param {module:query~ExprArg} name
+ * A string representing an AccessProvider's name
+ * @return {Expr}
+ */
+function AccessProvider(name) {
+  arity.exact(1, arguments, AccessProvider.name)
+  return new Expr({ access_provider: wrap(name) })
+}
+
 // Helpers
 
 /**
@@ -3235,5 +3246,6 @@ module.exports = {
   MoveDatabase: MoveDatabase,
   Documents: Documents,
   Reverse: Reverse,
+  AccessProvider: AccessProvider,
   wrap: wrap,
 }

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -260,4 +260,6 @@ export module query {
   export function ContainsField(field: string, _in: ExprArg): Expr
   export function ContainsValue(value: ExprArg, _in: ExprArg): Expr
   export function Reverse(expr: ExprArg): Expr
+
+  export function AccessProvider(name: ExprArg): Expr
 }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2625,8 +2625,34 @@ describe('query', () => {
   })
 
   test('access_provider', async () => {
-    // TODO: Add tests for AccessProvider here once we add
-    // CreateAccessProvider functionality for API v3
+    // Create a new AcessProvider
+    const providerName = util.randomString('provider_')
+    await adminClient.query(
+      query.CreateAccessProvider({
+        name: providerName,
+        issuer: util.randomString('issuer_'),
+        jwks_uri: `https://${util.randomString()}.com`,
+      })
+    )
+
+    // Successfully retrieve provider with Get(AccessProvider())
+    try {
+      const provider = await adminClient.query(
+        query.Get(query.AccessProvider(providerName))
+      )
+      expect(provider).toBeTruthy()
+      expect(provider.name).toEqual(providerName)
+    } catch (error) {
+      console.log(error)
+    }
+
+    // Fail to retrieve non-existent provider
+    const badProviderName = util.randomString('bad_provider_')
+    try {
+      await adminClient.query(query.Get(query.AccessProvider(badProviderName)))
+    } catch (error) {
+      expect(error).toBeInstanceOf(errors.BadRequest)
+    }
   })
 
   // Check arity of all query functions


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-669)

This PR adds the `AccessProvider` function, which users can use to fetch providers they've previously created:

```
client.query(query.Get(query.AccessProvider("my-provider"))
```


### How to test
Run `npm run test`