### PR TITLE
FE-664 | Add AccessProviders function

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -2889,6 +2889,17 @@ function Reverse(expr) {
   return new Expr({ reverse: wrap(expr) })
 }
 
+/**
+ *
+ * @param {module:query~ExprArg} name
+ * A string representing an AccessProvider's name
+ * @return {Expr}
+ */
+function AccessProvider(name) {
+  arity.exact(1, arguments, AccessProvider.name)
+  return new Expr({ access_provider: wrap(name) })
+}
+
 // Helpers
 
 /**
@@ -3235,5 +3246,6 @@ module.exports = {
   MoveDatabase: MoveDatabase,
   Documents: Documents,
   Reverse: Reverse,
+  AccessProvider: AccessProvider,
   wrap: wrap,
 }

--- a/src/query.js
+++ b/src/query.js
@@ -1820,6 +1820,7 @@ function Role(name, scope) {
  */
 function AccessProviders(scope) {
   arity.max(1, arguments, AccessProviders.name)
+  scope = defaults(scope, null)
   return new Expr({ access_providers: wrap(scope) })
 }
 

--- a/src/query.js
+++ b/src/query.js
@@ -1813,6 +1813,17 @@ function Role(name, scope) {
 }
 
 /**
+ *
+ * @param {module:query~ExprArg} scope
+ *   The Ref of the database set's scope.
+ * @return {Expr}
+ */
+function AccessProviders(scope) {
+  arity.max(1, arguments, AccessProviders.name)
+  return new Expr({ access_providers: wrap(scope) })
+}
+
+/**
  * See the [docs](https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions).
  *
  * Constructs a `classes` function that, when evaluated, returns a Ref value.
@@ -3156,6 +3167,7 @@ module.exports = {
   Collection: Collection,
   Function: FunctionFn,
   Role: Role,
+  AccessProviders: AccessProviders,
   Classes: deprecate(
     Classes,
     'Classes() is deprecated, use Collections() instead'

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -260,4 +260,6 @@ export module query {
   export function ContainsField(field: string, _in: ExprArg): Expr
   export function ContainsValue(value: ExprArg, _in: ExprArg): Expr
   export function Reverse(expr: ExprArg): Expr
+
+  export function AccessProvider(name: ExprArg): Expr
 }

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -182,6 +182,7 @@ export module query {
   export function Collection(name: ExprArg, scope?: ExprArg): Expr
   export function Function(name: ExprArg, scope?: ExprArg): Expr
   export function Role(name: ExprArg, scope?: ExprArg): Expr
+  export function AccessProviders(scope?: ExprArg): Expr
   export function Databases(scope?: ExprArg): Expr
   export function Classes(scope?: ExprArg): Expr
   export function Collections(scope?: ExprArg): Expr

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2655,6 +2655,46 @@ describe('query', () => {
     }
   })
 
+  test.only('access_providers', async () => {
+    const providerOne = await adminClient.query(
+      query.CreateAccessProvider({
+        name: util.randomString('provider_'),
+        issuer: util.randomString('issuer_'),
+        jwks_uri: `https://${util.randomString()}.com`,
+      })
+    )
+    console.log('providerOne', providerOne)
+
+    const providerTwo = await adminClient.query(
+      query.CreateAccessProvider({
+        name: util.randomString('provider_'),
+        issuer: util.randomString('issuer_'),
+        jwks_uri: `https://${util.randomString()}.com`,
+      })
+    )
+    console.log('providerTwo', providerTwo)
+
+    // Test use with Get()
+    try {
+      const providers = await adminClient.query(
+        query.Get(query.AccessProviders())
+      )
+      console.log(providers)
+    } catch (error) {
+      console.log(error)
+    }
+
+    // Test use with Paginate()
+    try {
+      const providers = await adminClient.query(
+        query.Paginate(query.AccessProviders())
+      )
+      console.log(providers)
+    } catch (error) {
+      console.log(error)
+    }
+  })
+
   // Check arity of all query functions
 
   test('arity', () => {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2625,8 +2625,34 @@ describe('query', () => {
   })
 
   test('access_provider', async () => {
-    // TODO: Add tests for AccessProvider here once we add
-    // CreateAccessProvider functionality for API v3
+    // Create a new AcessProvider
+    const providerName = util.randomString('provider_')
+    await adminClient.query(
+      query.CreateAccessProvider({
+        name: providerName,
+        issuer: util.randomString('issuer_'),
+        jwks_uri: `https://${util.randomString()}.com`,
+      })
+    )
+
+    // Successfully retrieve provider with Get(AccessProvider())
+    try {
+      const provider = await adminClient.query(
+        query.Get(query.AccessProvider(providerName))
+      )
+      expect(provider).toBeTruthy()
+      expect(provider.name).toEqual(providerName)
+    } catch (error) {
+      console.log(error)
+    }
+
+    // Fail to retrieve non-existent provider
+    const badProviderName = util.randomString('bad_provider_')
+    try {
+      await adminClient.query(query.Get(query.AccessProvider(badProviderName)))
+    } catch (error) {
+      expect(error).toBeInstanceOf(errors.BadRequest)
+    }
   })
 
   // Check arity of all query functions

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2574,7 +2574,7 @@ describe('query', () => {
       })
     )
 
-    const chance = await client.query(
+    await client.query(
       query.Create(query.Collection('widgets'), {
         data: {
           name: 'chance the rapper',
@@ -2583,7 +2583,7 @@ describe('query', () => {
       })
     )
 
-    const kendrick = await client.query(
+    await client.query(
       query.Create(query.Collection('widgets'), {
         data: {
           name: 'kendrick lamar',

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2655,31 +2655,34 @@ describe('query', () => {
     }
   })
 
-  test.only('access_providers', async () => {
-    const providerOne = await adminClient.query(
+  test('access_providers', async () => {
+    await adminClient.query(
       query.CreateAccessProvider({
         name: util.randomString('provider_'),
         issuer: util.randomString('issuer_'),
         jwks_uri: `https://${util.randomString()}.com`,
       })
     )
-    console.log('providerOne', providerOne)
 
-    const providerTwo = await adminClient.query(
+    await adminClient.query(
       query.CreateAccessProvider({
         name: util.randomString('provider_'),
         issuer: util.randomString('issuer_'),
         jwks_uri: `https://${util.randomString()}.com`,
       })
     )
-    console.log('providerTwo', providerTwo)
 
     // Test use with Get()
     try {
-      const providers = await adminClient.query(
+      const provider = await adminClient.query(
         query.Get(query.AccessProviders())
       )
-      console.log(providers)
+
+      expect(provider).toBeDefined()
+      expect(provider).toBeInstanceOf(Object)
+      expect(provider.name).toBeDefined()
+      expect(provider.issuer).toBeDefined()
+      expect(provider.jwks_uri).toBeDefined()
     } catch (error) {
       console.log(error)
     }
@@ -2689,7 +2692,11 @@ describe('query', () => {
       const providers = await adminClient.query(
         query.Paginate(query.AccessProviders())
       )
-      console.log(providers)
+
+      expect(providers).toBeDefined()
+      expect(providers).toBeInstanceOf(Object)
+      expect(providers.data).toBeInstanceOf(Array)
+      expect(providers.data.length).toBeGreaterThanOrEqual(1)
     } catch (error) {
       console.log(error)
     }


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-664)

This function allows users to query for the `AccessProvider`s they have set up in their database. They can use this function in one of two ways:

```
// Returns a single ref
client.query(query.Get(query.AccessProviders()))`

// Returns a list of refs
client.query(query.Paginate(query.AccessProviders()))`
```

This works pretty much the same way `Collections()` currently does 👍 

### How to test
Run `npm run test`
