### PR TITLE
FE-694 | Supported versioned @query values

### DIFF
--- a/src/Expr.js
+++ b/src/Expr.js
@@ -140,15 +140,13 @@ var exprToString = function(expr, caller) {
 
   if ('object' in expr) return printObject(expr['object'])
 
-  var keys = Object.keys(expr)
-  var fn = keys[0]
-
   // Versioned queries/lambdas will have an api_version field.
   // We want to prevent it from being parsed and displayed as:
   // Query(ApiVersion("3", "X", Var("X")))
-  if (fn === 'api_version') {
-    fn = keys[1]
-  }
+  var keys = Object.keys(expr).filter(
+    expression => expression !== 'api_version'
+  )
+  var fn = keys[0]
 
   // For FQL functions with special formatting concerns, we
   // use the specialCases object above to define their casing.
@@ -161,16 +159,10 @@ var exprToString = function(expr, caller) {
     })
     .join('')
 
-  var args = keys
-    .filter(key => {
-      // We don't want to include api_version values in
-      // our args and subsequent FQL string creation.
-      return key !== 'api_version'
-    })
-    .map(function(k) {
-      var v = expr[k]
-      return exprToString(v, fn)
-    })
+  var args = keys.map(function(k) {
+    var v = expr[k]
+    return exprToString(v, fn)
+  })
 
   var shouldReverseArgs = ['filter', 'map', 'foreach'].some(function(fn) {
     return fn in expr

--- a/src/Expr.js
+++ b/src/Expr.js
@@ -143,6 +143,13 @@ var exprToString = function(expr, caller) {
   var keys = Object.keys(expr)
   var fn = keys[0]
 
+  // Versioned queries/lambdas will have an api_version field.
+  // We want to prevent it from being parsed and displayed as:
+  // Query(ApiVersion("3", "X", Var("X")))
+  if (fn === 'api_version') {
+    fn = keys[1]
+  }
+
   // For FQL functions with special formatting concerns, we
   // use the specialCases object above to define their casing.
   if (fn in specialCases) fn = specialCases[fn]
@@ -154,10 +161,16 @@ var exprToString = function(expr, caller) {
     })
     .join('')
 
-  var args = keys.map(function(k) {
-    var v = expr[k]
-    return exprToString(v, fn)
-  })
+  var args = keys
+    .filter(key => {
+      // We don't want to include api_version values in
+      // our args and subsequent FQL string creation.
+      return key !== 'api_version'
+    })
+    .map(function(k) {
+      var v = expr[k]
+      return exprToString(v, fn)
+    })
 
   var shouldReverseArgs = ['filter', 'map', 'foreach'].some(function(fn) {
     return fn in expr

--- a/src/values.js
+++ b/src/values.js
@@ -347,14 +347,10 @@ Bytes.prototype.toJSON = function() {
  * @constructor
  */
 function Query(value) {
-  if (value.api_version === '3') {
-    this.value = {
-      lambda: value.lambda,
-      expr: value.expr,
-    }
-  } else {
-    this.value = value
-  }
+  this.api_version = value.api_version || null
+  delete value['api_version']
+
+  this.value = value
 }
 
 util.inherits(Query, Value)

--- a/src/values.js
+++ b/src/values.js
@@ -369,11 +369,9 @@ Query.prototype.toJSON = function() {
   return { '@query': this.value }
 }
 
-Object.defineProperty(Query.prototype, 'apiVersion', {
-  get() {
-    return this.api_version
-  },
-})
+Query.prototype.apiVersion = function() {
+  return this.api_version
+}
 
 /** @ignore */
 function wrapToString(type, fn) {

--- a/src/values.js
+++ b/src/values.js
@@ -347,7 +347,14 @@ Bytes.prototype.toJSON = function() {
  * @constructor
  */
 function Query(value) {
-  this.value = value
+  if (value.api_version === '3') {
+    this.value = {
+      lambda: value.lambda,
+      expr: value.expr,
+    }
+  } else {
+    this.value = value
+  }
 }
 
 util.inherits(Query, Value)

--- a/src/values.js
+++ b/src/values.js
@@ -343,7 +343,6 @@ Bytes.prototype.toJSON = function() {
 /** FaunaDB query. See the [docs](https://app.fauna.com/documentation/reference/queryapi#special-type).
  *
  * @param {any} value
- * @param {any} api_version
  * @extends module:values~Value
  * @constructor
  */

--- a/src/values.js
+++ b/src/values.js
@@ -348,13 +348,6 @@ Bytes.prototype.toJSON = function() {
  * @constructor
  */
 function Query(value) {
-  this.api_version = 'unstable'
-
-  if (value.api_version) {
-    this.api_version = value.api_version
-  }
-
-  delete value.api_version
   this.value = value
 }
 
@@ -367,10 +360,6 @@ wrapToString(Query, function() {
 /** @ignore */
 Query.prototype.toJSON = function() {
   return { '@query': this.value }
-}
-
-Query.prototype.apiVersion = function() {
-  return this.api_version
 }
 
 /** @ignore */

--- a/src/values.js
+++ b/src/values.js
@@ -343,15 +343,18 @@ Bytes.prototype.toJSON = function() {
 /** FaunaDB query. See the [docs](https://app.fauna.com/documentation/reference/queryapi#special-type).
  *
  * @param {any} value
+ * @param {any} api_version
  * @extends module:values~Value
  * @constructor
  */
 function Query(value) {
+  this.api_version = 'unstable'
+
   if (value.api_version) {
     this.api_version = value.api_version
-    delete value['api_version']
   }
 
+  delete value.api_version
   this.value = value
 }
 
@@ -365,6 +368,12 @@ wrapToString(Query, function() {
 Query.prototype.toJSON = function() {
   return { '@query': this.value }
 }
+
+Object.defineProperty(Query.prototype, 'apiVersion', {
+  get() {
+    return this.api_version
+  },
+})
 
 /** @ignore */
 function wrapToString(type, fn) {

--- a/src/values.js
+++ b/src/values.js
@@ -347,8 +347,10 @@ Bytes.prototype.toJSON = function() {
  * @constructor
  */
 function Query(value) {
-  this.api_version = value.api_version || null
-  delete value['api_version']
+  if (value.api_version) {
+    this.api_version = value.api_version
+    delete value['api_version']
+  }
 
   this.value = value
 }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -5,6 +5,7 @@ var values = require('../src/values')
 var query = require('../src/query')
 var util = require('./util')
 var Client = require('../src/Client')
+var _json = require('../src/_json')
 
 var Ref = query.Ref
 
@@ -2697,6 +2698,23 @@ describe('query', () => {
       expect(providers).toBeInstanceOf(Object)
       expect(providers.data).toBeInstanceOf(Array)
       expect(providers.data.length).toBeGreaterThanOrEqual(1)
+    } catch (error) {
+      console.log(error)
+    }
+  })
+
+  test('query returns version header', async () => {
+    const clientWithObserver = util.getClient({
+      observer: res => {
+        expect(res.responseRaw).toContain('api_version')
+        expect(res.responseRaw).toContain('3')
+      },
+    })
+
+    try {
+      await clientWithObserver.query(
+        query.Query(query.Lambda('X', query.Var('X')))
+      )
     } catch (error) {
       console.log(error)
     }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2710,7 +2710,6 @@ describe('query', () => {
       }
       const query = new values.Query(rawQuery['@query'])
 
-      expect(query.apiVersion()).toBe('3')
       expect(query.toString()).toBe(`Query(Lambda("X", Var("X")))`)
     } catch (error) {
       console.log(error)
@@ -2723,10 +2722,9 @@ describe('query', () => {
         query.Query(query.Lambda('X', query.Var('X')))
       )
 
-      expect(res.apiVersion()).toEqual('3')
       expect(res).toBeInstanceOf(values.Query)
       expect(res.toJSON()).toEqual({
-        '@query': { lambda: 'X', expr: { var: 'X' } },
+        '@query': { api_version: '3', lambda: 'X', expr: { var: 'X' } },
       })
     } catch (error) {
       console.log(error)

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2711,7 +2711,7 @@ describe('query', () => {
       }
       const query = new values.Query(rawQuery['@query'])
 
-      expect(query.apiVersion).toBe('3')
+      expect(query.apiVersion()).toBe('3')
       expect(query.toString()).toBe(`Query(Lambda("X", Var("X")))`)
     } catch (error) {
       console.log(error)
@@ -2724,7 +2724,7 @@ describe('query', () => {
         query.Query(query.Lambda('X', query.Var('X')))
       )
 
-      expect(res.apiVersion).toEqual('3')
+      expect(res.apiVersion()).toEqual('3')
       expect(res).toBeInstanceOf(values.Query)
       expect(res.toJSON()).toEqual({
         '@query': { lambda: 'X', expr: { var: 'X' } },

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2703,7 +2703,7 @@ describe('query', () => {
     }
   })
 
-  test.only('query returns versioned lambda field', async () => {
+  test('query returns versioned lambda field', async () => {
     const clientWithObserver = util.getClient({
       observer: res => {
         expect(res.responseRaw).toContain('api_version')
@@ -2720,7 +2720,14 @@ describe('query', () => {
     }
   })
 
-  // test.only('deserialize version lambdas correctly', async () => {})
+  test('deserialize version lambdas correctly', async () => {
+    const rawQuery = {
+      '@query': { api_version: '3', lambda: 'X', expr: { var: 'X' } },
+    }
+    const query = new values.Query(rawQuery['@query'])
+
+    expect(query.toString()).toBe(`Query(Lambda("X", Var("X")))`)
+  })
 
   // test.only('serialize version lambdas correctly', async () => {})
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -223,6 +223,7 @@ describe('query', () => {
         new values.Query({
           lambda: '_',
           expr: { let: { x: 1, y: 2 }, in: [{ var: 'x' }, { var: 'y' }] },
+          api_version: '3',
         })
       ),
     ])
@@ -338,7 +339,7 @@ describe('query', () => {
 
     return client.query(query.Query(lambda)).then(function(body) {
       return client.query(body).then(function(bodyEchoed) {
-        expect(body).toEqual(bodyEchoed)
+        expect(body.value).toEqual(bodyEchoed.value)
       })
     })
   })
@@ -2703,31 +2704,27 @@ describe('query', () => {
     }
   })
 
-  test.only('deserialize version lambdas correctly', async () => {
+  test('deserialize version lambdas correctly', async () => {
     try {
       const rawQuery = {
         '@query': { api_version: '3', lambda: 'X', expr: { var: 'X' } },
       }
       const query = new values.Query(rawQuery['@query'])
+
+      expect(query.apiVersion).toBe('3')
       expect(query.toString()).toBe(`Query(Lambda("X", Var("X")))`)
     } catch (error) {
       console.log(error)
     }
   })
 
-  test.only('serialize version lambdas correctly', async () => {
-    const clientWithObserver = util.getClient({
-      observer: res => {
-        expect(res.responseRaw).toContain('api_version')
-        expect(res.responseRaw).toContain('3')
-      },
-    })
-
+  test('serialize version lambdas correctly', async () => {
     try {
-      const res = await clientWithObserver.query(
+      const res = await client.query(
         query.Query(query.Lambda('X', query.Var('X')))
       )
 
+      expect(res.apiVersion).toEqual('3')
       expect(res).toBeInstanceOf(values.Query)
       expect(res.toJSON()).toEqual({
         '@query': { lambda: 'X', expr: { var: 'X' } },

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2703,7 +2703,19 @@ describe('query', () => {
     }
   })
 
-  test('query returns versioned lambda field', async () => {
+  test.only('deserialize version lambdas correctly', async () => {
+    try {
+      const rawQuery = {
+        '@query': { api_version: '3', lambda: 'X', expr: { var: 'X' } },
+      }
+      const query = new values.Query(rawQuery['@query'])
+      expect(query.toString()).toBe(`Query(Lambda("X", Var("X")))`)
+    } catch (error) {
+      console.log(error)
+    }
+  })
+
+  test.only('serialize version lambdas correctly', async () => {
     const clientWithObserver = util.getClient({
       observer: res => {
         expect(res.responseRaw).toContain('api_version')
@@ -2712,24 +2724,18 @@ describe('query', () => {
     })
 
     try {
-      await clientWithObserver.query(
+      const res = await clientWithObserver.query(
         query.Query(query.Lambda('X', query.Var('X')))
       )
+
+      expect(res).toBeInstanceOf(values.Query)
+      expect(res.toJSON()).toEqual({
+        '@query': { lambda: 'X', expr: { var: 'X' } },
+      })
     } catch (error) {
       console.log(error)
     }
   })
-
-  test('deserialize version lambdas correctly', async () => {
-    const rawQuery = {
-      '@query': { api_version: '3', lambda: 'X', expr: { var: 'X' } },
-    }
-    const query = new values.Query(rawQuery['@query'])
-
-    expect(query.toString()).toBe(`Query(Lambda("X", Var("X")))`)
-  })
-
-  // test.only('serialize version lambdas correctly', async () => {})
 
   // Check arity of all query functions
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2703,28 +2703,29 @@ describe('query', () => {
     }
   })
 
-  test('deserialize version lambdas correctly', async () => {
+  test('parse query/lambda version properly', () => {
     try {
       const rawQuery = {
         '@query': { api_version: '3', lambda: 'X', expr: { var: 'X' } },
       }
-      const query = new values.Query(rawQuery['@query'])
+      const newQuery = new values.Query(rawQuery['@query'])
+      const json = newQuery.toJSON()
 
-      expect(query.toString()).toBe(`Query(Lambda("X", Var("X")))`)
+      expect(json['@query'].api_version).toBe('3')
     } catch (error) {
       console.log(error)
     }
   })
 
-  test('serialize version lambdas correctly', async () => {
+  test('legacy queries/lambdas have default api_version', async () => {
     try {
       const res = await client.query(
-        query.Query(query.Lambda('X', query.Var('X')))
+        new values.Query({ lambda: 'X', expr: { var: 'X' } })
       )
 
       expect(res).toBeInstanceOf(values.Query)
       expect(res.toJSON()).toEqual({
-        '@query': { api_version: '3', lambda: 'X', expr: { var: 'X' } },
+        '@query': { api_version: '2.12', lambda: 'X', expr: { var: 'X' } },
       })
     } catch (error) {
       console.log(error)

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -338,7 +338,7 @@ describe('query', () => {
 
     return client.query(query.Query(lambda)).then(function(body) {
       return client.query(body).then(function(bodyEchoed) {
-        expect(body.value).toEqual(bodyEchoed.value)
+        expect(body).toEqual(bodyEchoed)
       })
     })
   })

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2703,7 +2703,7 @@ describe('query', () => {
     }
   })
 
-  test('query returns version header', async () => {
+  test.only('query returns versioned lambda field', async () => {
     const clientWithObserver = util.getClient({
       observer: res => {
         expect(res.responseRaw).toContain('api_version')
@@ -2719,6 +2719,10 @@ describe('query', () => {
       console.log(error)
     }
   })
+
+  // test.only('deserialize version lambdas correctly', async () => {})
+
+  // test.only('serialize version lambdas correctly', async () => {})
 
   // Check arity of all query functions
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -5,7 +5,6 @@ var values = require('../src/values')
 var query = require('../src/query')
 var util = require('./util')
 var Client = require('../src/Client')
-var _json = require('../src/_json')
 
 var Ref = query.Ref
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2703,33 +2703,15 @@ describe('query', () => {
     }
   })
 
-  test('parse query/lambda version properly', () => {
-    try {
-      const rawQuery = {
-        '@query': { api_version: '3', lambda: 'X', expr: { var: 'X' } },
-      }
-      const newQuery = new values.Query(rawQuery['@query'])
-      const json = newQuery.toJSON()
-
-      expect(json['@query'].api_version).toBe('3')
-    } catch (error) {
-      console.log(error)
-    }
-  })
-
   test('legacy queries/lambdas have default api_version', async () => {
-    try {
-      const res = await client.query(
-        new values.Query({ lambda: 'X', expr: { var: 'X' } })
-      )
+    const res = await client.query(
+      new values.Query({ lambda: 'X', expr: { var: 'X' } })
+    )
 
-      expect(res).toBeInstanceOf(values.Query)
-      expect(res.toJSON()).toEqual({
-        '@query': { api_version: '2.12', lambda: 'X', expr: { var: 'X' } },
-      })
-    } catch (error) {
-      console.log(error)
-    }
+    expect(res).toBeInstanceOf(values.Query)
+    expect(res.toJSON()).toEqual({
+      '@query': { api_version: '2.12', lambda: 'X', expr: { var: 'X' } },
+    })
   })
 
   // Check arity of all query functions

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -138,6 +138,18 @@ describe('Values', () => {
     expect(json.parseJSON(test_query_json)).toEqual(test_query)
   })
 
+  test('versioned query', () => {
+    var test_query = new Query({
+      api_version: '3',
+      lambda: 'x',
+      expr: { var: 'x' },
+    })
+    var test_query_json =
+      '{"@query":{"api_version":"3","lambda":"x","expr":{"var":"x"}}}'
+    expect(json.toJSON(test_query)).toEqual(test_query_json)
+    expect(json.parseJSON(test_query_json)).toEqual(test_query)
+  })
+
   var assertPrint = function(value, expected) {
     expect(expected).toEqual(util.inspect(value, { depth: null }))
     expect(expected).toEqual(value.toString())
@@ -451,11 +463,6 @@ describe('Values', () => {
     )
 
     // versioned queries/lambdas
-    assertPrint(
-      new Query({ lambda: 'X', expr: { var: 'X' } }),
-      `Query(Lambda("X", Var("X")))`
-    )
-
     assertPrint(
       new Query({ api_version: '2.12', lambda: 'X', expr: { var: 'X' } }),
       `Query(Lambda("X", Var("X")))`

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -449,5 +449,21 @@ describe('Values', () => {
       new Query(q.Lambda('_', Symbol('foo'))),
       'Query(Lambda("_", "foo"))'
     )
+
+    // versioned queries/lambdas
+    assertPrint(
+      new Query({ lambda: 'X', expr: { var: 'X' } }),
+      `Query(Lambda("X", Var("X")))`
+    )
+
+    assertPrint(
+      new Query({ api_version: '2.12', lambda: 'X', expr: { var: 'X' } }),
+      `Query(Lambda("X", Var("X")))`
+    )
+
+    assertPrint(
+      new Query({ api_version: '3', lambda: 'X', expr: { var: 'X' } }),
+      `Query(Lambda("X", Var("X")))`
+    )
   })
 })

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -150,26 +150,6 @@ describe('Values', () => {
     expect(json.parseJSON(test_query_json)).toEqual(test_query)
   })
 
-  test.only('parse versioned query despite protocol arg order', () => {
-    var test_query = new Query({
-      lambda: 'x',
-      expr: { var: 'x' },
-      api_version: '3',
-    })
-
-    var x = '{"@query":{"api_version":"3","lambda":"x","expr":{"var":"x"}}}'
-    expect(json.parseJSON(x)).toEqual(test_query)
-    expect(json.parseJSON(x).toString()).toEqual(test_query.toString())
-
-    var y = '{"@query":{"lambda":"x","api_version":"3","expr":{"var":"x"}}}'
-    expect(json.parseJSON(y)).toEqual(test_query)
-    expect(json.parseJSON(y).toString()).toEqual(test_query.toString())
-
-    // var z = '{"@query":{"expr":{"var":"x"},"lambda":"x","api_version":"3"}}'
-    // expect(json.parseJSON(z)).toEqual(test_query)
-    // expect(json.parseJSON(z).toString()).toEqual(test_query.toString())
-  })
-
   var assertPrint = function(value, expected) {
     expect(expected).toEqual(util.inspect(value, { depth: null }))
     expect(expected).toEqual(value.toString())

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -150,6 +150,26 @@ describe('Values', () => {
     expect(json.parseJSON(test_query_json)).toEqual(test_query)
   })
 
+  test.only('parse versioned query despite protocol arg order', () => {
+    var test_query = new Query({
+      lambda: 'x',
+      expr: { var: 'x' },
+      api_version: '3',
+    })
+
+    var x = '{"@query":{"api_version":"3","lambda":"x","expr":{"var":"x"}}}'
+    expect(json.parseJSON(x)).toEqual(test_query)
+    expect(json.parseJSON(x).toString()).toEqual(test_query.toString())
+
+    var y = '{"@query":{"lambda":"x","api_version":"3","expr":{"var":"x"}}}'
+    expect(json.parseJSON(y)).toEqual(test_query)
+    expect(json.parseJSON(y).toString()).toEqual(test_query.toString())
+
+    // var z = '{"@query":{"expr":{"var":"x"},"lambda":"x","api_version":"3"}}'
+    // expect(json.parseJSON(z)).toEqual(test_query)
+    // expect(json.parseJSON(z).toString()).toEqual(test_query.toString())
+  })
+
   var assertPrint = function(value, expected) {
     expect(expected).toEqual(util.inspect(value, { depth: null }))
     expect(expected).toEqual(value.toString())
@@ -470,6 +490,11 @@ describe('Values', () => {
 
     assertPrint(
       new Query({ api_version: '3', lambda: 'X', expr: { var: 'X' } }),
+      `Query(Lambda("X", Var("X")))`
+    )
+
+    assertPrint(
+      new Query({ lambda: 'X', expr: { var: 'X' }, api_version: '3' }),
       `Query(Lambda("X", Var("X")))`
     )
   })

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -472,10 +472,5 @@ describe('Values', () => {
       new Query({ api_version: '3', lambda: 'X', expr: { var: 'X' } }),
       `Query(Lambda("X", Var("X")))`
     )
-
-    assertPrint(
-      new Query({ lambda: 'X', expr: { var: 'X' }, api_version: '3' }),
-      `Query(Lambda("X", Var("X")))`
-    )
   })
 })


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-694)

This PR adds support for versions Query/Lambda values.

### How to test
Run the test suite with `npm run test`