### PR TITLE
FE-714 | Split AccessProvider work into its own branch

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -1024,6 +1024,23 @@ function CreateRole(params) {
   return new Expr({ create_role: wrap(params) })
 }
 
+/**
+ * See the [docs](https://app.fauna.com/documentation/reference/queryapi#write-functions).
+ *
+ * @param {module:query~ExprArg} params
+ *   An object of parameters used to create a new access provider.
+ *     - name: A valid schema name
+ *     - issuer: A unique string
+ *     - jwks_uri: A valid HTTPS URI
+ *     - allowed_roles: An optional list of Role refs
+ *     - allowed_collections: An optional list of user-defined Collection refs
+ * @return {Expr}
+ */
+function CreateAccessProvider(params) {
+  arity.exact(1, arguments, CreateAccessProvider.name)
+  return new Expr({ create_access_provider: wrap(params) })
+}
+
 // Sets
 
 /**
@@ -1793,6 +1810,18 @@ function Role(name, scope) {
   arity.between(1, 2, arguments, Role.name)
   scope = defaults(scope, null)
   return new Expr(params({ role: wrap(name) }, { scope: wrap(scope) }))
+}
+
+/**
+ *
+ * @param {module:query~ExprArg} scope
+ *   The Ref of the database set's scope.
+ * @return {Expr}
+ */
+function AccessProviders(scope) {
+  arity.max(1, arguments, AccessProviders.name)
+  scope = defaults(scope, null)
+  return new Expr({ access_providers: wrap(scope) })
 }
 
 /**
@@ -2872,6 +2901,17 @@ function Reverse(expr) {
   return new Expr({ reverse: wrap(expr) })
 }
 
+/**
+ *
+ * @param {module:query~ExprArg} name
+ * A string representing an AccessProvider's name
+ * @return {Expr}
+ */
+function AccessProvider(name) {
+  arity.exact(1, arguments, AccessProvider.name)
+  return new Expr({ access_provider: wrap(name) })
+}
+
 // Helpers
 
 /**
@@ -3074,6 +3114,7 @@ module.exports = {
   CreateKey: CreateKey,
   CreateFunction: CreateFunction,
   CreateRole: CreateRole,
+  CreateAccessProvider: CreateAccessProvider,
   Singleton: Singleton,
   Events: Events,
   Match: Match,
@@ -3127,6 +3168,7 @@ module.exports = {
   Collection: Collection,
   Function: FunctionFn,
   Role: Role,
+  AccessProviders: AccessProviders,
   Classes: deprecate(
     Classes,
     'Classes() is deprecated, use Collections() instead'
@@ -3217,5 +3259,6 @@ module.exports = {
   MoveDatabase: MoveDatabase,
   Documents: Documents,
   Reverse: Reverse,
+  AccessProvider: AccessProvider,
   wrap: wrap,
 }

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -94,6 +94,7 @@ export module query {
   export function CreateKey(params: ExprArg): Expr
   export function CreateFunction(params: ExprArg): Expr
   export function CreateRole(params: ExprArg): Expr
+  export function CreateAccessProvider(params: ExprArg): Expr
 
   export function Singleton(ref: ExprArg): Expr
   export function Events(ref_set: ExprArg): Expr
@@ -181,6 +182,7 @@ export module query {
   export function Collection(name: ExprArg, scope?: ExprArg): Expr
   export function Function(name: ExprArg, scope?: ExprArg): Expr
   export function Role(name: ExprArg, scope?: ExprArg): Expr
+  export function AccessProviders(scope?: ExprArg): Expr
   export function Databases(scope?: ExprArg): Expr
   export function Classes(scope?: ExprArg): Expr
   export function Collections(scope?: ExprArg): Expr
@@ -259,4 +261,6 @@ export module query {
   export function ContainsField(field: string, _in: ExprArg): Expr
   export function ContainsValue(value: ExprArg, _in: ExprArg): Expr
   export function Reverse(expr: ExprArg): Expr
+
+  export function AccessProvider(name: ExprArg): Expr
 }

--- a/src/types/values.d.ts
+++ b/src/types/values.d.ts
@@ -25,6 +25,7 @@ export module values {
     static readonly DATABASES: Ref
     static readonly KEYS: Ref
     static readonly FUNCTIONS: Ref
+    static readonly ACCESS_PROVIDERS: Ref
   }
 
   export class SetRef extends Value {

--- a/src/values.js
+++ b/src/values.js
@@ -123,11 +123,14 @@ wrapToString(Ref, function() {
     indexes: 'Index',
     functions: 'Function',
     roles: 'Role',
+    access_providers: 'AccessProvider',
   }
 
   var toString = function(ref) {
     if (ref.collection === undefined) {
       var db = ref.database !== undefined ? ref.database.toString() : ''
+
+      if (ref.id === 'access_providers') return 'AccessProviders(' + db + ')'
 
       return ref.id.charAt(0).toUpperCase() + ref.id.slice(1) + '(' + db + ')'
     }
@@ -173,6 +176,7 @@ var Native = {
   FUNCTIONS: new Ref('functions'),
   ROLES: new Ref('roles'),
   KEYS: new Ref('keys'),
+  ACCESS_PROVIDERS: new Ref('access_providers'),
 }
 
 Native.fromName = function(name) {
@@ -189,6 +193,8 @@ Native.fromName = function(name) {
       return Native.ROLES
     case 'keys':
       return Native.KEYS
+    case 'access_providers':
+      return Native.ACCESS_PROVIDERS
   }
   return new Ref(name)
 }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -849,6 +849,78 @@ describe('query', () => {
     })
   })
 
+  test('create access provider', async () => {
+    const providerName = util.randomString('provider_')
+    const issuerName = util.randomString('issuer_')
+    const jwksUri = util.randomString()
+    const fullUri = `https://${jwksUri}.auth0.com`
+
+    // Successful instantiation with required fields
+    const provider = await adminClient.query(
+      query.CreateAccessProvider({
+        name: providerName,
+        issuer: issuerName,
+        jwks_uri: fullUri,
+      })
+    )
+
+    expect(provider.name).toEqual(providerName)
+    expect(provider.issuer).toEqual(issuerName)
+    expect(provider.jwks_uri).toEqual(fullUri)
+
+    // Failure due to non-unique issuer
+    try {
+      await adminClient.query(
+        query.CreateAccessProvider({
+          name: 'duplicate_provider',
+          issuer: issuerName,
+          jwks_uri: 'https://db.fauna.com',
+        })
+      )
+    } catch (error) {
+      expect(error).toBeInstanceOf(errors.BadRequest)
+    }
+
+    // Failure due to missing name
+    try {
+      await adminClient.query(
+        query.CreateAccessProvider({
+          name: null,
+          issuer: issuerName,
+          jwks_uri: fullUri,
+        })
+      )
+    } catch (error) {
+      expect(error).toBeInstanceOf(errors.BadRequest)
+    }
+
+    // Failure due to missing issuer
+    try {
+      await adminClient.query(
+        query.CreateAccessProvider({
+          name: providerName,
+          issuer: null,
+          jwks_uri: fullUri,
+        })
+      )
+    } catch (error) {
+      expect(error).toBeInstanceOf(errors.BadRequest)
+    }
+
+    // Failure due to invalid URI
+    try {
+      await adminClient.query(
+        query.CreateAccessProvider({
+          name: providerName,
+          issuer: issuerName,
+          jwks_uri: jwksUri,
+        })
+      )
+    } catch (error) {
+      expect(error).toBeInstanceOf(errors.BadRequest)
+    }
+  })
+
   // Sets
 
   test('events', () => {
@@ -2551,6 +2623,84 @@ describe('query', () => {
     expect(databases.data).toEqual(reverseDBs.data.reverse())
     expect(documentsSet.data).toEqual(reverseDocumentsSet.data.reverse())
     expect(multiPage.data).toEqual(reverseMultiPage.data.reverse())
+  })
+
+  test('access_provider', async () => {
+    // Create a new AcessProvider
+    const providerName = util.randomString('provider_')
+    await adminClient.query(
+      query.CreateAccessProvider({
+        name: providerName,
+        issuer: util.randomString('issuer_'),
+        jwks_uri: `https://${util.randomString()}.auth0.com`,
+      })
+    )
+
+    // Successfully retrieve provider with Get(AccessProvider())
+    try {
+      const provider = await adminClient.query(
+        query.Get(query.AccessProvider(providerName))
+      )
+      expect(provider).toBeTruthy()
+      expect(provider.name).toEqual(providerName)
+    } catch (error) {
+      console.log(error)
+    }
+
+    // Fail to retrieve non-existent provider
+    const badProviderName = util.randomString('bad_provider_')
+    try {
+      await adminClient.query(query.Get(query.AccessProvider(badProviderName)))
+    } catch (error) {
+      expect(error).toBeInstanceOf(errors.BadRequest)
+    }
+  })
+
+  test('access_providers', async () => {
+    await adminClient.query(
+      query.CreateAccessProvider({
+        name: util.randomString('provider_'),
+        issuer: util.randomString('issuer_'),
+        jwks_uri: `https://${util.randomString()}.auth0.com`,
+      })
+    )
+
+    await adminClient.query(
+      query.CreateAccessProvider({
+        name: util.randomString('provider_'),
+        issuer: util.randomString('issuer_'),
+        jwks_uri: `https://${util.randomString()}.auth0.com`,
+      })
+    )
+
+    // Test use with Get()
+    try {
+      const provider = await adminClient.query(
+        query.Get(query.AccessProviders())
+      )
+
+      expect(provider).toBeDefined()
+      expect(provider).toBeInstanceOf(Object)
+      expect(provider.name).toBeDefined()
+      expect(provider.issuer).toBeDefined()
+      expect(provider.jwks_uri).toBeDefined()
+    } catch (error) {
+      console.log(error)
+    }
+
+    // Test use with Paginate()
+    try {
+      const providers = await adminClient.query(
+        query.Paginate(query.AccessProviders())
+      )
+
+      expect(providers).toBeDefined()
+      expect(providers).toBeInstanceOf(Object)
+      expect(providers.data).toBeInstanceOf(Array)
+      expect(providers.data.length).toBeGreaterThanOrEqual(1)
+    } catch (error) {
+      console.log(error)
+    }
   })
 
   test('legacy queries/lambdas have default api_version', async () => {

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -162,6 +162,10 @@ describe('Values', () => {
     assertPrint(new Ref('fn', values.Native.FUNCTIONS), 'Function("fn")')
     assertPrint(new Ref('role', values.Native.ROLES), 'Role("role")')
     assertPrint(new Ref('key', values.Native.KEYS), 'Ref(Keys(), "key")')
+    assertPrint(
+      new Ref('access_provider', values.Native.ACCESS_PROVIDERS),
+      'AccessProvider("access_provider")'
+    )
 
     assertPrint(values.Native.COLLECTIONS, 'Collections()')
     assertPrint(values.Native.DATABASES, 'Databases()')
@@ -169,6 +173,7 @@ describe('Values', () => {
     assertPrint(values.Native.FUNCTIONS, 'Functions()')
     assertPrint(values.Native.ROLES, 'Roles()')
     assertPrint(values.Native.KEYS, 'Keys()')
+    assertPrint(values.Native.ACCESS_PROVIDERS, 'AccessProviders()')
 
     var db = new Ref('db', values.Native.DATABASES)
 
@@ -178,6 +183,10 @@ describe('Values', () => {
     assertPrint(new Ref('functions', null, db), 'Functions(Database("db"))')
     assertPrint(new Ref('roles', null, db), 'Roles(Database("db"))')
     assertPrint(new Ref('keys', null, db), 'Keys(Database("db"))')
+    assertPrint(
+      new Ref('access_providers', null, db),
+      'AccessProviders(Database("db"))'
+    )
 
     assertPrint(
       new Ref('col', values.Native.COLLECTIONS, db),
@@ -198,6 +207,10 @@ describe('Values', () => {
     assertPrint(
       new Ref('role', values.Native.ROLES, db),
       'Role("role", Database("db"))'
+    )
+    assertPrint(
+      new Ref('access_provider', values.Native.ACCESS_PROVIDERS, db),
+      'AccessProvider("access_provider", Database("db"))'
     )
 
     assertPrint(


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-714)

To prepare for API v3, we removed all of the `AccessProvider` functionality (#316) as the functionality is currently being reconsidered. This branch/PR represents all of the work we've done thus far.