### PR TITLE
chore: update release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "browserify-min": "browserify index.js --standalone faunadb | terser -c -m --keep-fnames --keep-classnames -o dist/faunadb-min.js",
     "prettify": "prettier --write \"{src,test}/**/*.{js,ts}\"",
     "test": "jest --env=node --verbose=false ./test",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release --tag-format ${version}"
   },
   "types": "index.d.ts",
   "dependencies": {


### PR DESCRIPTION
### Notes
Last week, we tested this workflow with the `dryRun` flag and `semantic-release` was picking up v2.10.0 as our most recent tag and using that to decide what the new version number would be. This is strange since `git tag` and GitHub both show that our most recent tag is `2.14.2`.

In reading through the documentation, this is because semantic-release uses the tag format `vX.Y.Z` by default whereas our tags use `X.Y.Z` format.