### PR TITLE
chore: remove dryRun flag in release config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Npm Version](https://img.shields.io/npm/v/faunadb.svg?maxAge=21600)](https://www.npmjs.com/package/faunadb)
 [![License](https://img.shields.io/badge/license-MPL_2.0-blue.svg?maxAge=2592000)](https://raw.githubusercontent.com/fauna/faunadb-js/master/LICENSE)
 
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+
 A Javascript driver for [FaunaDB](https://fauna.com).
 
 [View reference JSDocs here](https://fauna.github.com/faunadb-js).

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     ]
   },
   "release": {
-    "dryRun": true,
     "branches": [
       "master"
     ]


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-727)

This PR updates our GitHub Actions release pipeline by doing the following:
- Removing the `dryRun` flag from the semantic-release config in `package.json`