### PR TITLE
FE-750 | Remove special cases from array

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var APIVersion = '3'
+var APIVersion = 'UNSTABLE'
 
 var btoa = require('btoa-lite')
 var errors = require('./errors')

--- a/src/Expr.js
+++ b/src/Expr.js
@@ -52,25 +52,11 @@ var varArgsFunctions = [
 // Core update: https://faunadb.atlassian.net/browse/ENG-2110
 
 var specialCases = {
-  containsstrregex: 'ContainsStrRegex',
-  endswith: 'EndsWith',
-  findstr: 'FindStr',
-  findstrregex: 'FindStrRegex',
   gt: 'GT',
   gte: 'GTE',
   is_nonempty: 'is_non_empty',
-  lowercase: 'LowerCase',
   lt: 'LT',
   lte: 'LTE',
-  ltrim: 'LTrim',
-  rtrim: 'RTrim',
-  regexescape: 'RegexEscape',
-  replacestr: 'ReplaceStr',
-  replacestrregex: 'ReplaceStrRegex',
-  startswith: 'StartsWith',
-  substring: 'SubString',
-  titlecase: 'TitleCase',
-  uppercase: 'UpperCase',
 }
 
 /**

--- a/src/Expr.js
+++ b/src/Expr.js
@@ -249,6 +249,70 @@ var exprToString = function(expr, caller) {
     )
   }
 
+  if ('collections' in expr) {
+    if (expr['collections'] === null) {
+      return 'Collections()'
+    }
+  }
+
+  if ('databases' in expr) {
+    if (expr['databases'] === null) {
+      return 'Databases()'
+    }
+  }
+
+  if ('select' in expr) {
+    return (
+      'Select(' +
+      exprToString(expr['select']) +
+      ', ' +
+      exprToString(expr['from']) +
+      ')'
+    )
+  }
+
+  if ('if' in expr) {
+    return (
+      'If(' +
+      exprToString(expr['if']) +
+      ', ' +
+      exprToString(expr['then']) +
+      ', ' +
+      exprToString(expr['else']) +
+      ')'
+    )
+  }
+
+  if ('contains_path' in expr) {
+    return (
+      'ContainsPath(' +
+      exprToString(expr['contains_path']) +
+      ', ' +
+      exprToString(expr['in']) +
+      ')'
+    )
+  }
+
+  if ('contains_field' in expr) {
+    return (
+      'ContainsField(' +
+      exprToString(expr['contains_field']) +
+      ', ' +
+      exprToString(expr['in']) +
+      ')'
+    )
+  }
+
+  if ('contains_value' in expr) {
+    return (
+      'ContainsValue(' +
+      exprToString(expr['contains_value']) +
+      ', ' +
+      exprToString(expr['in']) +
+      ')'
+    )
+  }
+
   var keys = Object.keys(expr)
   var fn = keys[0]
   fn = convertToCamelCase(fn)

--- a/src/Expr.js
+++ b/src/Expr.js
@@ -261,6 +261,24 @@ var exprToString = function(expr, caller) {
     }
   }
 
+  if ('functions' in expr) {
+    if (expr['functions'] === null) {
+      return 'Functions()'
+    }
+  }
+
+  if ('indexes' in expr) {
+    if (expr['indexes'] === null) {
+      return 'Indexes()'
+    }
+  }
+
+  if ('roles' in expr) {
+    if (expr['roles'] === null) {
+      return 'Roles()'
+    }
+  }
+
   if ('select' in expr) {
     return (
       'Select(' +

--- a/src/query.js
+++ b/src/query.js
@@ -1280,7 +1280,7 @@ function Casefold(string, normalizer) {
  */
 function ContainsStr(value, search) {
   arity.exact(2, arguments, ContainsStr.name)
-  return new Expr({ containsstr: wrap(value), search: wrap(search) })
+  return new Expr({ contains_str: wrap(value), search: wrap(search) })
 }
 
 /**
@@ -1293,7 +1293,7 @@ function ContainsStr(value, search) {
  */
 function ContainsStrRegex(value, pattern) {
   arity.exact(2, arguments, ContainsStrRegex.name)
-  return new Expr({ containsstrregex: wrap(value), pattern: wrap(pattern) })
+  return new Expr({ contains_str_regex: wrap(value), pattern: wrap(pattern) })
 }
 
 /**
@@ -1306,7 +1306,7 @@ function ContainsStrRegex(value, pattern) {
  */
 function StartsWith(value, search) {
   arity.exact(2, arguments, StartsWith.name)
-  return new Expr({ startswith: wrap(value), search: wrap(search) })
+  return new Expr({ starts_with: wrap(value), search: wrap(search) })
 }
 
 /**
@@ -1319,7 +1319,7 @@ function StartsWith(value, search) {
  */
 function EndsWith(value, search) {
   arity.exact(2, arguments, EndsWith.name)
-  return new Expr({ endswith: wrap(value), search: wrap(search) })
+  return new Expr({ ends_with: wrap(value), search: wrap(search) })
 }
 
 /**
@@ -1331,7 +1331,7 @@ function EndsWith(value, search) {
  */
 function RegexEscape(value) {
   arity.exact(1, arguments, RegexEscape.name)
-  return new Expr({ regexescape: wrap(value) })
+  return new Expr({ regex_escape: wrap(value) })
 }
 
 /**
@@ -1346,7 +1346,7 @@ function FindStr(value, find, start) {
   arity.between(2, 3, arguments, FindStr.name)
   start = defaults(start, null)
   return new Expr(
-    params({ findstr: wrap(value), find: wrap(find) }, { start: wrap(start) })
+    params({ find_str: wrap(value), find: wrap(find) }, { start: wrap(start) })
   )
 }
 
@@ -1364,7 +1364,7 @@ function FindStrRegex(value, pattern, start, numResults) {
   start = defaults(start, null)
   return new Expr(
     params(
-      { findstrregex: wrap(value), pattern: wrap(pattern) },
+      { find_str_regex: wrap(value), pattern: wrap(pattern) },
       { start: wrap(start), num_results: wrap(numResults) }
     )
   )
@@ -1389,7 +1389,7 @@ function Length(value) {
  */
 function LowerCase(value) {
   arity.exact(1, arguments, LowerCase.name)
-  return new Expr({ lowercase: wrap(value) })
+  return new Expr({ lower_case: wrap(value) })
 }
 
 /**
@@ -1400,7 +1400,7 @@ function LowerCase(value) {
  */
 function LTrim(value) {
   arity.exact(1, arguments, LTrim.name)
-  return new Expr({ ltrim: wrap(value) })
+  return new Expr({ l_trim: wrap(value) })
 }
 
 /**
@@ -1448,7 +1448,7 @@ function Repeat(value, number) {
 function ReplaceStr(value, find, replace) {
   arity.exact(3, arguments, ReplaceStr.name)
   return new Expr({
-    replacestr: wrap(value),
+    replace_str: wrap(value),
     find: wrap(find),
     replace: wrap(replace),
   })
@@ -1469,7 +1469,7 @@ function ReplaceStrRegex(value, pattern, replace, first) {
   return new Expr(
     params(
       {
-        replacestrregex: wrap(value),
+        replace_str_regex: wrap(value),
         pattern: wrap(pattern),
         replace: wrap(replace),
       },
@@ -1486,7 +1486,7 @@ function ReplaceStrRegex(value, pattern, replace, first) {
  */
 function RTrim(value) {
   arity.exact(1, arguments, RTrim.name)
-  return new Expr({ rtrim: wrap(value) })
+  return new Expr({ r_trim: wrap(value) })
 }
 
 /**
@@ -1513,7 +1513,7 @@ function SubString(value, start, length) {
   length = defaults(length, null)
   return new Expr(
     params(
-      { substring: wrap(value) },
+      { sub_string: wrap(value) },
       { start: wrap(start), length: wrap(length) }
     )
   )
@@ -1527,7 +1527,7 @@ function SubString(value, start, length) {
  */
 function TitleCase(value) {
   arity.exact(1, arguments, TitleCase.name)
-  return new Expr({ titlecase: wrap(value) })
+  return new Expr({ title_case: wrap(value) })
 }
 
 /**
@@ -1549,7 +1549,7 @@ function Trim(value) {
  */
 function UpperCase(value) {
   arity.exact(1, arguments, UpperCase.name)
-  return new Expr({ uppercase: wrap(value) })
+  return new Expr({ upper_case: wrap(value) })
 }
 
 /**
@@ -2096,7 +2096,7 @@ function Add() {
  */
 function BitAnd() {
   arity.min(1, arguments, BitAnd.name)
-  return new Expr({ bitand: wrap(varargs(arguments)) })
+  return new Expr({ bit_and: wrap(varargs(arguments)) })
 }
 
 /**
@@ -2108,7 +2108,7 @@ function BitAnd() {
  */
 function BitNot(expr) {
   arity.exact(1, arguments, BitNot.name)
-  return new Expr({ bitnot: wrap(expr) })
+  return new Expr({ bit_not: wrap(expr) })
 }
 
 /**
@@ -2120,7 +2120,7 @@ function BitNot(expr) {
  */
 function BitOr() {
   arity.min(1, arguments, BitOr.name)
-  return new Expr({ bitor: wrap(varargs(arguments)) })
+  return new Expr({ bit_or: wrap(varargs(arguments)) })
 }
 
 /**
@@ -2132,7 +2132,7 @@ function BitOr() {
  */
 function BitXor() {
   arity.min(1, arguments, BitXor.name)
-  return new Expr({ bitxor: wrap(varargs(arguments)) })
+  return new Expr({ bit_xor: wrap(varargs(arguments)) })
 }
 
 /**

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -419,10 +419,9 @@ describe('query', () => {
   test('take', () => {
     var p1 = assertQuery(query.Take(1, [1, 2]), [1])
     var p2 = assertQuery(query.Take(3, [1, 2]), [1, 2])
-    // var p3 = assertQuery(query.Take(-1, [1, 2]), [])
+    var p3 = assertQuery(query.Take(-1, [1, 2]), [2])
 
-    // return Promise.all([p1, p2, p3])
-    return Promise.all([p1, p2])
+    return Promise.all([p1, p2, p3])
   })
 
   test('drop', () => {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -222,7 +222,7 @@ describe('query', () => {
         new values.Query({
           lambda: '_',
           expr: { let: { x: 1, y: 2 }, in: [{ var: 'x' }, { var: 'y' }] },
-          api_version: '3',
+          api_version: 'UNSTABLE',
         })
       ),
       assertQuery(
@@ -419,9 +419,10 @@ describe('query', () => {
   test('take', () => {
     var p1 = assertQuery(query.Take(1, [1, 2]), [1])
     var p2 = assertQuery(query.Take(3, [1, 2]), [1, 2])
-    var p3 = assertQuery(query.Take(-1, [1, 2]), [])
+    // var p3 = assertQuery(query.Take(-1, [1, 2]), [])
 
-    return Promise.all([p1, p2, p3])
+    // return Promise.all([p1, p2, p3])
+    return Promise.all([p1, p2])
   })
 
   test('drop', () => {
@@ -1568,13 +1569,13 @@ describe('query', () => {
     return Promise.all([p1, p2, p3, p4])
   })
 
-  test('contains', () => {
-    var obj = { a: { b: 1 } }
-    var p1 = assertQuery(query.Contains(['a', 'b'], obj), true)
-    var p2 = assertQuery(query.Contains('a', obj), true)
-    var p3 = assertQuery(query.Contains(['a', 'c'], obj), false)
-    return Promise.all([p1, p2, p3])
-  })
+  // test('contains', () => {
+  //   var obj = { a: { b: 1 } }
+  //   var p1 = assertQuery(query.Contains(['a', 'b'], obj), true)
+  //   var p2 = assertQuery(query.Contains('a', obj), true)
+  //   var p3 = assertQuery(query.Contains(['a', 'c'], obj), false)
+  //   return Promise.all([p1, p2, p3])
+  // })
 
   test('contains_value arrays', () => {
     var arr = [1, [2, 3]]
@@ -2324,19 +2325,19 @@ describe('query', () => {
     )
   })
 
-  test('bytes', () => {
-    return Promise.all([
-      assertQuery(query.Bytes('AQIDBA=='), new Bytes('AQIDBA==')),
-      assertQuery(
-        query.Bytes(new Uint8Array([0, 0, 0, 0])),
-        new Bytes('AAAAAA==')
-      ),
-      assertQuery(query.Bytes(new ArrayBuffer(4)), new Bytes('AAAAAA==')),
-      assertQuery(new Bytes('AQIDBA=='), new Bytes('AQIDBA==')),
-      assertQuery(new Uint8Array([0, 0, 0, 0]), new Bytes('AAAAAA==')),
-      assertQuery(new ArrayBuffer(4), new Bytes('AAAAAA==')),
-    ])
-  })
+  // test('bytes', () => {
+  //   return Promise.all([
+  //     assertQuery(query.Bytes('AQIDBA=='), new Bytes('AQIDBA==')),
+  //     assertQuery(
+  //       query.Bytes(new Uint8Array([0, 0, 0, 0])),
+  //       new Bytes('AAAAAA==')
+  //     ),
+  //     assertQuery(query.Bytes(new ArrayBuffer(4)), new Bytes('AAAAAA==')),
+  //     assertQuery(new Bytes('AQIDBA=='), new Bytes('AQIDBA==')),
+  //     assertQuery(new Uint8Array([0, 0, 0, 0]), new Bytes('AAAAAA==')),
+  //     assertQuery(new ArrayBuffer(4), new Bytes('AAAAAA==')),
+  //   ])
+  // })
 
   test('recursive refs', () => {
     return withNewDatabase().then(function(adminCli) {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2316,19 +2316,19 @@ describe('query', () => {
     )
   })
 
-  // test('bytes', () => {
-  //   return Promise.all([
-  //     assertQuery(query.Bytes('AQIDBA=='), new Bytes('AQIDBA==')),
-  //     assertQuery(
-  //       query.Bytes(new Uint8Array([0, 0, 0, 0])),
-  //       new Bytes('AAAAAA==')
-  //     ),
-  //     assertQuery(query.Bytes(new ArrayBuffer(4)), new Bytes('AAAAAA==')),
-  //     assertQuery(new Bytes('AQIDBA=='), new Bytes('AQIDBA==')),
-  //     assertQuery(new Uint8Array([0, 0, 0, 0]), new Bytes('AAAAAA==')),
-  //     assertQuery(new ArrayBuffer(4), new Bytes('AAAAAA==')),
-  //   ])
-  // })
+  test('bytes', () => {
+    return Promise.all([
+      assertQuery(query.Bytes('AQIDBA=='), new Bytes('AQIDBA==')),
+      assertQuery(
+        query.Bytes(new Uint8Array([0, 0, 0, 0])),
+        new Bytes('AAAAAA==')
+      ),
+      assertQuery(query.Bytes(new ArrayBuffer(4)), new Bytes('AAAAAA==')),
+      assertQuery(new Bytes('AQIDBA=='), new Bytes('AQIDBA==')),
+      assertQuery(new Uint8Array([0, 0, 0, 0]), new Bytes('AAAAAA==')),
+      assertQuery(new ArrayBuffer(4), new Bytes('AAAAAA==')),
+    ])
+  })
 
   test('recursive refs', () => {
     return withNewDatabase().then(function(adminCli) {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1568,14 +1568,6 @@ describe('query', () => {
     return Promise.all([p1, p2, p3, p4])
   })
 
-  // test('contains', () => {
-  //   var obj = { a: { b: 1 } }
-  //   var p1 = assertQuery(query.Contains(['a', 'b'], obj), true)
-  //   var p2 = assertQuery(query.Contains('a', obj), true)
-  //   var p3 = assertQuery(query.Contains(['a', 'c'], obj), false)
-  //   return Promise.all([p1, p2, p3])
-  // })
-
   test('contains_value arrays', () => {
     var arr = [1, [2, 3]]
     var nestedArrValues = [[1], [2], [3]]

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -602,7 +602,7 @@ describe('Values', () => {
         filter: {
           lambda: 'i',
           expr: {
-            containsstr: { select: 'name', from: { get: { var: 'i' } } },
+            contains_str: { select: 'name', from: { get: { var: 'i' } } },
             search: '-',
           },
         },

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -810,4 +810,109 @@ describe('Values', () => {
       'Query(Lambda("x", Let([{y: Var("x")}], Add(1, Var("y")))))'
     )
   })
+
+  test('test non-snake cased functions', () => {
+    assertPrint(
+      new Query({
+        regex_escape: '.Fa*[un]a{1,}',
+      }),
+      'Query(RegexEscape(".Fa*[un]a{1,}"))'
+    )
+
+    assertPrint(
+      new Query({
+        starts_with: 'Fauna',
+        search: 'F',
+      }),
+      'Query(StartsWith("Fauna", "F"))'
+    )
+
+    assertPrint(
+      new Query({
+        ends_with: 'Fauna',
+        search: 'a',
+      }),
+      'Query(EndsWith("Fauna", "a"))'
+    )
+
+    assertPrint(
+      new Query({
+        contains_str: 'Fauna',
+        search: 'una',
+      }),
+      'Query(ContainsStr("Fauna", "una"))'
+    )
+
+    assertPrint(
+      new Query({
+        contains_str_regex: 'Fauna',
+        pattern: '(Fa|na)',
+      }),
+      'Query(ContainsStrRegex("Fauna", "(Fa|na)"))'
+    )
+
+    assertPrint(
+      new Query({
+        find_str: 'fire and fireman',
+        find: 'fire',
+      }),
+      'Query(FindStr("fire and fireman", "fire"))'
+    )
+
+    assertPrint(
+      new Query({ find_str_regex: 'fire and Fireman', pattern: '[Ff]ire' }),
+      'Query(FindStrRegex("fire and Fireman", "[Ff]ire"))'
+    )
+
+    assertPrint(
+      new Query({ lower_case: 'Fire And FireMan' }),
+      'Query(LowerCase("Fire And FireMan"))'
+    )
+
+    assertPrint(new Query({ l_trim: ' Fire' }), 'Query(LTrim(" Fire"))')
+
+    assertPrint(
+      new Query({
+        replace_str: 'One Fish Two Fish',
+        find: 'Two',
+        replace: 'Blue',
+      }),
+      'Query(ReplaceStr("One Fish Two Fish", "Two", "Blue"))'
+    )
+
+    assertPrint(
+      new Query({
+        replace_str_regex: 'One Fisk Two FisT',
+        pattern: 'Fis.',
+        replace: 'Fish',
+        first: true,
+      }),
+      'Query(ReplaceStrRegex("One Fisk Two FisT", "Fis.", "Fish", true))'
+    )
+
+    assertPrint(new Query({ r_trim: 'Fire  ' }), 'Query(RTrim("Fire  "))')
+
+    assertPrint(
+      new Query({ sub_string: 'ABCDEFGHIJK', start: 2, length: 3 }),
+      'Query(SubString("ABCDEFGHIJK", 2, 3))'
+    )
+
+    assertPrint(
+      new Query({ title_case: 'FIRE And FireMan' }),
+      'Query(TitleCase("FIRE And FireMan"))'
+    )
+
+    assertPrint(
+      new Query({ upper_case: 'Fire And FireMan' }),
+      'Query(UpperCase("Fire And FireMan"))'
+    )
+
+    assertPrint(new Query({ bit_and: [0, 0] }), 'Query(BitAnd(0, 0))')
+
+    assertPrint(new Query({ bit_not: 7 }), 'Query(BitNot(7))')
+
+    assertPrint(new Query({ bit_or: [0, 0] }), 'Query(BitOr(0, 0))')
+
+    assertPrint(new Query({ bit_xor: [0, 0] }), 'Query(BitXor(0, 0))')
+  })
 })


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-750)

In [this PR](https://faunadb.atlassian.net/browse/FE-750), we updated our function names in Core to all be snake_cased. This means we can remove a number of "special cases" from our lookup which handles improperly formatted function names that come over the wire.

### How to test
Run `npm run test`