### PR TITLE
FE-762 | feat: add CurrentIdentity()

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -1234,6 +1234,16 @@ function Identity() {
  *
  * @return {Expr}
  */
+function CurrentIdentity() {
+  arity.exact(0, arguments, CurrentIdentity.name)
+  return new Expr({ current_identity: null })
+}
+
+/**
+ * See the [docs](https://app.fauna.com/documentation/reference/queryapi#authentication).
+ *
+ * @return {Expr}
+ */
 function HasIdentity() {
   arity.exact(0, arguments, HasIdentity.name)
   return new Expr({ has_identity: null })
@@ -3128,7 +3138,11 @@ module.exports = {
   Login: Login,
   Logout: Logout,
   Identify: Identify,
-  Identity: Identity,
+  Identity: deprecate(
+    Identity,
+    'Identity() is deprecated, use CurrentIdentity() instead'
+  ),
+  CurrentIdentity: CurrentIdentity,
   HasIdentity: HasIdentity,
   Concat: Concat,
   Casefold: Casefold,

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -110,6 +110,7 @@ export module query {
   export function Logout(delete_tokens: ExprArg): Expr
   export function Identify(ref: ExprArg, password: ExprArg): Expr
   export function Identity(): Expr
+  export function CurrentIdentity(): Expr
   export function HasIdentity(): Expr
 
   export function Concat(strings: ExprArg, separator?: ExprArg): Expr

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2715,6 +2715,9 @@ describe('query', () => {
     }
   })
 
+  // TODO Create tests once work is done in Core
+  test.skip('current_identity', () => {})
+
   test('legacy queries/lambdas have default api_version', async () => {
     const res = await client.query(
       new values.Query({ lambda: 'X', expr: { var: 'X' } })


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-762)

This PR does the following:
- Adds `CurrentIdentity`, which has the same functionality as `Identity`
- Deprecates `Identity`

### How to test
We cannot test this until the work in Core has been finished.
