### PR TITLE
FE-763 | feat: add HasCurrentIdentity()

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -1239,6 +1239,16 @@ function HasIdentity() {
   return new Expr({ has_identity: null })
 }
 
+/**
+ * See the [docs](https://app.fauna.com/documentation/reference/queryapi#authentication).
+ *
+ * @return {Expr}
+ */
+function HasCurrentIdentity() {
+  arity.exact(0, arguments, HasCurrentIdentity.name)
+  return new Expr({ has_current_identity: null })
+}
+
 // String functions
 
 /**
@@ -3129,7 +3139,11 @@ module.exports = {
   Logout: Logout,
   Identify: Identify,
   Identity: Identity,
-  HasIdentity: HasIdentity,
+  HasIdentity: deprecate(
+    HasIdentity,
+    'HasIdentity() is deprecated, use HasCurrentIdentity() instead'
+  ),
+  HasCurrentIdentity: HasCurrentIdentity,
   Concat: Concat,
   Casefold: Casefold,
   ContainsStr: ContainsStr,

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -111,6 +111,7 @@ export module query {
   export function Identify(ref: ExprArg, password: ExprArg): Expr
   export function Identity(): Expr
   export function HasIdentity(): Expr
+  export function HasCurrentIdentity(): Expr
 
   export function Concat(strings: ExprArg, separator?: ExprArg): Expr
   export function Casefold(string: ExprArg, normalizer?: ExprArg): Expr

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2715,6 +2715,9 @@ describe('query', () => {
     }
   })
 
+  // TODO Add test once Core work has been done
+  test.skip('has_current_identity', () => {})
+
   test('legacy queries/lambdas have default api_version', async () => {
     const res = await client.query(
       new values.Query({ lambda: 'X', expr: { var: 'X' } })


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-763)

This PR does the following:
1. Adds `HasCurrentIdentity()` which has the same functionality as `HasIdentity()`
2. Deprecates `HasIdentity()`

### How to test
We can't test this properly until the Core work is done