### PR TITLE
FE-765 | feat: add HasCurrentToken()

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -1239,6 +1239,16 @@ function HasIdentity() {
   return new Expr({ has_identity: null })
 }
 
+/**
+ * See the [docs](https://app.fauna.com/documentation/reference/queryapi#authentication).
+ *
+ * @return {Expr}
+ */
+function HasCurrentToken() {
+  arity.exact(0, arguments, HasCurrentToken.name)
+  return new Expr({ has_current_token: null })
+}
+
 // String functions
 
 /**
@@ -3130,6 +3140,7 @@ module.exports = {
   Identify: Identify,
   Identity: Identity,
   HasIdentity: HasIdentity,
+  HasCurrentToken: HasCurrentToken,
   Concat: Concat,
   Casefold: Casefold,
   ContainsStr: ContainsStr,

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -111,6 +111,7 @@ export module query {
   export function Identify(ref: ExprArg, password: ExprArg): Expr
   export function Identity(): Expr
   export function HasIdentity(): Expr
+  export function HasCurrentToken(): Expr
 
   export function Concat(strings: ExprArg, separator?: ExprArg): Expr
   export function Casefold(string: ExprArg, normalizer?: ExprArg): Expr

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2715,6 +2715,9 @@ describe('query', () => {
     }
   })
 
+  // TODO Define test once Core work is done
+  test.skip('has_current_token', () => {})
+
   test('legacy queries/lambdas have default api_version', async () => {
     const res = await client.query(
       new values.Query({ lambda: 'X', expr: { var: 'X' } })


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-765)

This PR adds the `HasCurrentToken()` function and a stub for the tests.

### How to test
This cannot be tested without the Core image being updated to include these new functions.