### PR TITLE
FE-768 | Update tests for CreateAccessProvider

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var APIVersion = '3'
+var APIVersion = '4'
 
 var btoa = require('btoa-lite')
 var errors = require('./errors')

--- a/src/query.js
+++ b/src/query.js
@@ -1032,8 +1032,7 @@ function CreateRole(params) {
  *     - name: A valid schema name
  *     - issuer: A unique string
  *     - jwks_uri: A valid HTTPS URI
- *     - allowed_roles: An optional list of Role refs
- *     - allowed_collections: An optional list of user-defined Collection refs
+ *     - membership: An array of roles
  * @return {Expr}
  */
 function CreateAccessProvider(params) {
@@ -1253,7 +1252,8 @@ function HasIdentity() {
  * See the [docs](https://app.fauna.com/documentation/reference/queryapi#authentication).
  *
  * @return {Expr}
- */  
+ */
+
 function HasCurrentIdentity() {
   arity.exact(0, arguments, HasCurrentIdentity.name)
   return new Expr({ has_current_identity: null })
@@ -1268,7 +1268,7 @@ function CurrentToken() {
   arity.exact(0, arguments, CurrentToken.name)
   return new Expr({ current_token: null })
 }
-  
+
 /**
  * See the [docs](https://app.fauna.com/documentation/reference/queryapi#authentication).
  *

--- a/src/query.js
+++ b/src/query.js
@@ -1032,7 +1032,8 @@ function CreateRole(params) {
  *     - name: A valid schema name
  *     - issuer: A unique string
  *     - jwks_uri: A valid HTTPS URI
- *     - membership: An array of roles
+ *     - membership: An array of role/predicate pairs where the predicate returns a boolean.
+ *                   The array can also contain Role references.
  * @return {Expr}
  */
 function CreateAccessProvider(params) {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -222,7 +222,7 @@ describe('query', () => {
         new values.Query({
           lambda: '_',
           expr: { let: { x: 1, y: 2 }, in: [{ var: 'x' }, { var: 'y' }] },
-          api_version: '3',
+          api_version: '4',
         })
       ),
       assertQuery(

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -870,7 +870,7 @@ describe('query', () => {
     const roleTwoName = util.randomString('role_two_')
 
     // Create roles
-    const myNewRole = await adminClient.query(
+    await adminClient.query(
       query.CreateRole({
         name: roleOneName,
         privileges: [
@@ -882,7 +882,7 @@ describe('query', () => {
       })
     )
 
-    const anotherNewRole = await adminClient.query(
+    await adminClient.query(
       query.CreateRole({
         name: roleTwoName,
         privileges: [
@@ -902,7 +902,7 @@ describe('query', () => {
           issuer: issuerName,
           jwks_uri: fullUri,
           membership: [
-            myNewRole,
+            query.Role(`${roleOneName}`),
             {
               role: query.Role(`${roleTwoName}`),
               predicate: query.Query(query.Lambda(x => true)),

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1607,14 +1607,6 @@ describe('query', () => {
     return Promise.all([p1, p2, p3, p4])
   })
 
-  test('contains', () => {
-    var obj = { a: { b: 1 } }
-    var p1 = assertQuery(query.Contains(['a', 'b'], obj), true)
-    var p2 = assertQuery(query.Contains('a', obj), true)
-    var p3 = assertQuery(query.Contains(['a', 'c'], obj), false)
-    return Promise.all([p1, p2, p3])
-  })
-
   test('contains_value arrays', () => {
     var arr = [1, [2, 3]]
     var nestedArrValues = [[1], [2], [3]]

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -861,7 +861,7 @@ describe('query', () => {
     })
   })
 
-  test.only('create_access_provider', async () => {
+  test('create_access_provider', async () => {
     const providerName = util.randomString('provider_')
     const issuerName = util.randomString('issuer_')
     const jwksUri = util.randomString()

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1607,6 +1607,14 @@ describe('query', () => {
     return Promise.all([p1, p2, p3, p4])
   })
 
+  test('contains', () => {
+    var obj = { a: { b: 1 } }
+    var p1 = assertQuery(query.Contains(['a', 'b'], obj), true)
+    var p2 = assertQuery(query.Contains('a', obj), true)
+    var p3 = assertQuery(query.Contains(['a', 'c'], obj), false)
+    return Promise.all([p1, p2, p3])
+  })
+
   test('contains_value arrays', () => {
     var arr = [1, [2, 3]]
     var nestedArrValues = [[1], [2], [3]]

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -861,7 +861,7 @@ describe('query', () => {
     })
   })
 
-  test('create_access_provider', async () => {
+  test('create_access_provider successful creation', async () => {
     const providerName = util.randomString('provider_')
     const issuerName = util.randomString('issuer_')
     const jwksUri = util.randomString()
@@ -894,81 +894,170 @@ describe('query', () => {
       })
     )
 
-    // Successful instantiation with required fields
-    try {
-      const provider = await adminClient.query(
-        query.CreateAccessProvider({
-          name: providerName,
-          issuer: issuerName,
-          jwks_uri: fullUri,
-          membership: [
-            query.Role(roleOneName),
-            {
-              role: query.Role(`${roleTwoName}`),
-              predicate: query.Query(query.Lambda(x => true)),
-            },
-          ],
-        })
-      )
+    const provider = await adminClient.query(
+      query.CreateAccessProvider({
+        name: providerName,
+        issuer: issuerName,
+        jwks_uri: fullUri,
+        membership: [
+          query.Role(roleOneName),
+          {
+            role: query.Role(`${roleTwoName}`),
+            predicate: query.Query(query.Lambda(x => true)),
+          },
+        ],
+      })
+    )
 
-      expect(provider.name).toEqual(providerName)
-      expect(provider.issuer).toEqual(issuerName)
-      expect(provider.jwks_uri).toEqual(fullUri)
-      expect(provider.membership).toBeInstanceOf(Array)
-    } catch (error) {
-      expect(error).toBeInstanceOf(errors.BadRequest)
-    }
+    expect(provider.name).toEqual(providerName)
+    expect(provider.issuer).toEqual(issuerName)
+    expect(provider.jwks_uri).toEqual(fullUri)
+    expect(provider.membership).toBeInstanceOf(Array)
+  })
 
-    // Failure due to non-unique issuer
+  test('create_access_provider fails with non-unique issuer', async () => {
+    const issuerName = util.randomString('issuer_')
+    const roleOneName = util.randomString('role_one_')
+    const providerName = util.randomString('provider_')
+    const jwksUri = util.randomString()
+    const fullUri = `https://${jwksUri}.auth0.com`
+
+    // Create Role
+    await adminClient.query(
+      query.CreateRole({
+        name: roleOneName,
+        privileges: [
+          {
+            resource: query.Databases(),
+            actions: { read: true },
+          },
+        ],
+      })
+    )
+
+    // Create initial provider
+    const provider = await adminClient.query(
+      query.CreateAccessProvider({
+        name: providerName,
+        issuer: issuerName,
+        jwks_uri: fullUri,
+        membership: [query.Role(roleOneName)],
+      })
+    )
+
+    // Create provider with duplicate issuer value
     try {
       await adminClient.query(
         query.CreateAccessProvider({
           name: 'duplicate_provider',
           issuer: issuerName,
           jwks_uri: 'https://db.fauna.com',
+          membership: [query.Role(roleOneName)],
         })
       )
-    } catch (error) {
-      expect(error).toBeInstanceOf(errors.BadRequest)
+    } catch (err) {
+      expect(err).toBeInstanceOf(errors.BadRequest)
     }
+  })
 
-    // Failure due to missing name
-    try {
-      await adminClient.query(
-        query.CreateAccessProvider({
-          name: null,
-          issuer: issuerName,
-          jwks_uri: fullUri,
-        })
-      )
-    } catch (error) {
-      expect(error).toBeInstanceOf(errors.BadRequest)
-    }
+  test('create_access_provider fails without issuer', async () => {
+    const providerName = util.randomString('provider_')
+    const jwksUri = util.randomString()
+    const fullUri = `https://${jwksUri}.auth0.com`
+    const roleOneName = util.randomString('role_one_')
 
-    // Failure due to missing issuer
+    // Create Role
+    await adminClient.query(
+      query.CreateRole({
+        name: roleOneName,
+        privileges: [
+          {
+            resource: query.Databases(),
+            actions: { read: true },
+          },
+        ],
+      })
+    )
+
+    // Create provider without issuer
     try {
       await adminClient.query(
         query.CreateAccessProvider({
           name: providerName,
           issuer: null,
           jwks_uri: fullUri,
+          membership: [query.Role(roleOneName)],
         })
       )
-    } catch (error) {
-      expect(error).toBeInstanceOf(errors.BadRequest)
+    } catch (err) {
+      expect(err).toBeInstanceOf(errors.BadRequest)
     }
+  })
 
-    // Failure due to invalid URI
+  test('create_access_provider fails without name', async () => {
+    const issuerName = util.randomString('issuer_')
+    const jwksUri = util.randomString()
+    const fullUri = `https://${jwksUri}.auth0.com`
+    const roleOneName = util.randomString('role_one_')
+
+    // Create Role
+    await adminClient.query(
+      query.CreateRole({
+        name: roleOneName,
+        privileges: [
+          {
+            resource: query.Databases(),
+            actions: { read: true },
+          },
+        ],
+      })
+    )
+
+    // Create provider without name
+    try {
+      await adminClient.query(
+        query.CreateAccessProvider({
+          issuer: issuerName,
+          jwks_uri: fullUri,
+          membership: [query.Role(roleOneName)],
+        })
+      )
+    } catch (err) {
+      expect(err).toBeInstanceOf(errors.BadRequest)
+    }
+  })
+
+  test('create_access_provider fails with invalid URI', async () => {
+    const providerName = util.randomString('provider_')
+    const issuerName = util.randomString('issuer_')
+    const jwksUri = util.randomString()
+    const roleOneName = util.randomString('role_one_')
+
+    // Create Role
+    await adminClient.query(
+      query.CreateRole({
+        name: roleOneName,
+        privileges: [
+          {
+            resource: query.Databases(),
+            actions: { read: true },
+          },
+        ],
+      })
+    )
+
+    // Create provider with invalid
     try {
       await adminClient.query(
         query.CreateAccessProvider({
           name: providerName,
           issuer: issuerName,
           jwks_uri: jwksUri,
+          membership: [query.Role(roleOneName)],
         })
       )
-    } catch (error) {
-      expect(error).toBeInstanceOf(errors.BadRequest)
+    } catch (err) {
+      expect(err).toBeInstanceOf(errors.BadRequest)
     }
   })
 


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-768)

**NOTE:** #339 needs to be merged first in order for these tests to pass CI

This PR updates the test coverage for `CreateAccessProvider` to reflect the new functionality. Specifically, we now have a `membership` field whose value is an array of Roles.

### How to test
Using the `nightly` version of our Core image locally, you can run `npm run test`
