### PR TITLE
FE-788 | Add API v4 tests

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var APIVersion = '3'
+var APIVersion = '4'
 
 var btoa = require('btoa-lite')
 var errors = require('./errors')

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2784,7 +2784,7 @@ describe('query', () => {
   })
 
   test('has_current_token returns false when no token present', async () => {
-    const hasCurrentToken = await adminClient.query(query.HasCurrentIdentity())
+    const hasCurrentToken = await client.query(query.HasCurrentToken())
     expect(hasCurrentToken).toBeFalsy()
   })
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2772,11 +2772,12 @@ describe('query', () => {
   })
 
   test('current_token fails when unauthenticated', async () => {
+    const newClient = new Client()
+
     try {
-      const currentToken = await client.query(query.CurrentToken())
-      throw currentToken
+      const currentToken = await newClient.query(query.CurrentToken())
     } catch (err) {
-      expect(err).toBeInstanceOf(errors.BadRequest)
+      expect(err).toBeInstanceOf(errors.Unauthorized)
     }
   })
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -222,7 +222,7 @@ describe('query', () => {
         new values.Query({
           lambda: '_',
           expr: { let: { x: 1, y: 2 }, in: [{ var: 'x' }, { var: 'y' }] },
-          api_version: '3',
+          api_version: '4',
         })
       ),
       assertQuery(
@@ -2710,7 +2710,7 @@ describe('query', () => {
 
   // API v4 AccessProvider functions
 
-  test.only('current_identity returns object when authed', async () => {
+  test('current_identity returns object when authed', async () => {
     // Create a new Collection
     const newCollection = await client.query(
       query.Create(collectionRef, { credentials: { password: 'sekrit' } })
@@ -2731,7 +2731,7 @@ describe('query', () => {
     expect(currentIdentity).toBeInstanceOf(Object)
   })
 
-  test.only('current_identity fails when no identity present', async () => {
+  test('current_identity fails when no identity present', async () => {
     try {
       await adminClient.query(query.CurrentIdentity())
     } catch (err) {
@@ -2739,14 +2739,31 @@ describe('query', () => {
     }
   })
 
-  test.only('has_current_identity returns true when identity present', async () => {})
+  test('has_current_identity returns true when identity present', async () => {
+    // Create a new Collection
+    const newCollection = await client.query(
+      query.Create(collectionRef, { credentials: { password: 'sekrit' } })
+    )
 
-  test.only('has_current_identity returns false without identity present', async () => {
+    // Login with permissions for newly created Collection
+    const newLogin = await client.query(
+      query.Login(newCollection['ref'], { password: 'sekrit' })
+    )
+
+    // Get the newly scoped client
+    const newClient = await util.getClient({ secret: newLogin['secret'] })
+
+    // Retrieve the current identity
+    const currentIdentity = await newClient.query(query.CurrentIdentity())
+    expect(currentIdentity).toBeTruthy()
+  })
+
+  test('has_current_identity returns false without identity present', async () => {
     const currentIdentity = await adminClient.query(query.HasCurrentIdentity())
     expect(currentIdentity).toBeFalsy()
   })
 
-  test.only('current_token returns object with AccessProvider', async () => {
+  test('current_token returns object with AccessProvider', async () => {
     const roleOneName = util.randomString('role_one_')
     const issuerName = util.randomString('issuer_')
     const providerName = util.randomString('provider_')
@@ -2781,7 +2798,7 @@ describe('query', () => {
     expect(currentToken).toBeInstanceOf(Object)
   })
 
-  test.only('current_token fails when unauthenticated', async () => {
+  test('current_token fails when unauthenticated', async () => {
     try {
       await adminClient.query(query.CurrentToken())
     } catch (err) {
@@ -2789,7 +2806,7 @@ describe('query', () => {
     }
   })
 
-  test.only('has_current_token returns true when token present', async () => {
+  test('has_current_token returns true when token present', async () => {
     const roleOneName = util.randomString('role_one_')
     const issuerName = util.randomString('issuer_')
     const providerName = util.randomString('provider_')
@@ -2823,7 +2840,7 @@ describe('query', () => {
     expect(hasCurrentToken).toBeTruthy()
   })
 
-  test.only('has_current_token returns false when no token present', async () => {
+  test('has_current_token returns false when no token present', async () => {
     const hasCurrentToken = await adminClient.query(query.HasCurrentIdentity())
     expect(hasCurrentToken).toBeFalsy()
   })

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2770,7 +2770,39 @@ describe('query', () => {
     }
   })
 
-  test.only('has_current_token returns true when token present', () => {})
+  test.only('has_current_token returns true when token present', async () => {
+    const roleOneName = util.randomString('role_one_')
+    const issuerName = util.randomString('issuer_')
+    const providerName = util.randomString('provider_')
+    const jwksUri = util.randomString()
+    const fullUri = `https://${jwksUri}.auth0.com`
+
+    // Create Role
+    await adminClient.query(
+      query.CreateRole({
+        name: roleOneName,
+        privileges: [
+          {
+            resource: query.Databases(),
+            actions: { read: true },
+          },
+        ],
+      })
+    )
+
+    // Create AccessProvider
+    await adminClient.query(
+      query.CreateAccessProvider({
+        name: providerName,
+        issuer: issuerName,
+        jwks_uri: fullUri,
+        membership: [query.Role(roleOneName)],
+      })
+    )
+
+    const hasCurrentToken = adminClient.query(query.HasCurrentToken())
+    expect(hasCurrentToken).toBeTruthy()
+  })
 
   test.only('has_current_token returns false when no token present', async () => {
     const hasCurrentToken = await adminClient.query(query.HasCurrentIdentity())

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2774,6 +2774,7 @@ describe('query', () => {
   test('current_token fails when unauthenticated', async () => {
     try {
       const currentToken = await client.query(query.CurrentToken())
+      throw currentToken
     } catch (err) {
       expect(err).toBeInstanceOf(errors.BadRequest)
     }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2710,7 +2710,7 @@ describe('query', () => {
 
   // API v4 AccessProvider functions
 
-  test.skip('current_identity returns sub field from JWT', async () => {})
+  test.only('current_identity returns sub field from JWT', async () => {})
 
   test.only('current_identity fails when no identity present', async () => {
     try {
@@ -2720,14 +2720,47 @@ describe('query', () => {
     }
   })
 
-  test.skip('has_current_identity returns true when identity present', async () => {})
+  test.only('has_current_identity returns true when identity present', async () => {})
 
   test.only('has_current_identity returns false without identity present', async () => {
     const currentIdentity = await adminClient.query(query.HasCurrentIdentity())
     expect(currentIdentity).toBeFalsy()
   })
 
-  test.skip('current_token returns Ref or object', () => {})
+  test.only('current_token returns object with AccessProvider', async () => {
+    const roleOneName = util.randomString('role_one_')
+    const issuerName = util.randomString('issuer_')
+    const providerName = util.randomString('provider_')
+    const jwksUri = util.randomString()
+    const fullUri = `https://${jwksUri}.auth0.com`
+
+    // Create Role
+    await adminClient.query(
+      query.CreateRole({
+        name: roleOneName,
+        privileges: [
+          {
+            resource: query.Databases(),
+            actions: { read: true },
+          },
+        ],
+      })
+    )
+
+    // Create AccessProvider
+    await adminClient.query(
+      query.CreateAccessProvider({
+        name: providerName,
+        issuer: issuerName,
+        jwks_uri: fullUri,
+        membership: [query.Role(roleOneName)],
+      })
+    )
+
+    // Retrieve Ref
+    const currentToken = await adminClient.query(query.CurrentToken())
+    expect(currentToken).toBeInstanceOf(Object)
+  })
 
   test.only('current_token fails when unauthenticated', async () => {
     try {
@@ -2737,7 +2770,7 @@ describe('query', () => {
     }
   })
 
-  test.skip('has_current_token returns true when token present', () => {})
+  test.only('has_current_token returns true when token present', () => {})
 
   test.only('has_current_token returns false when no token present', async () => {
     const hasCurrentToken = await adminClient.query(query.HasCurrentIdentity())

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2711,6 +2711,7 @@ describe('query', () => {
   })
 
   // API v4 AccessProvider functions
+  // TODO: Add tests for JWTs using Auth0/Okta
 
   test('current_identity returns object when authed', async () => {
     // Create a new Collection

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2773,7 +2773,7 @@ describe('query', () => {
 
   test('current_token fails when unauthenticated', async () => {
     try {
-      await adminClient.query(query.CurrentToken())
+      const currentToken = await client.query(query.CurrentToken())
     } catch (err) {
       expect(err).toBeInstanceOf(errors.BadRequest)
     }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2710,7 +2710,26 @@ describe('query', () => {
 
   // API v4 AccessProvider functions
 
-  test.only('current_identity returns sub field from JWT', async () => {})
+  test.only('current_identity returns object when authed', async () => {
+    // Create a new Collection
+    const newCollection = await client.query(
+      query.Create(collectionRef, { credentials: { password: 'sekrit' } })
+    )
+
+    // Login with permissions for newly created Collection
+    const newLogin = await client.query(
+      query.Login(newCollection['ref'], { password: 'sekrit' })
+    )
+
+    // Get the newly scoped client
+    const newClient = await util.getClient({ secret: newLogin['secret'] })
+
+    // Retrieve the current identity
+    const currentIdentity = await newClient.query(query.CurrentIdentity())
+    expect(currentIdentity).toEqual(newCollection.ref)
+    expect(currentIdentity).toEqual(newLogin.instance)
+    expect(currentIdentity).toBeInstanceOf(Object)
+  })
 
   test.only('current_identity fails when no identity present', async () => {
     try {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2864,6 +2864,8 @@ describe('query', () => {
   test('current_identity fails when no identity present', async () => {
     try {
       await adminClient.query(query.CurrentIdentity())
+      
+      throw new Error('Should not reached here')
     } catch (err) {
       expect(err).toBeInstanceOf(errors.BadRequest)
     }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -28,6 +28,8 @@ var collectionRef,
   thimbleCollectionRef
 
 describe('query', () => {
+  let adminKey = null
+
   beforeAll(async () => {
     // Hideous way to ensure that the client is initialized.
     client = util.client()
@@ -38,7 +40,7 @@ describe('query', () => {
     const serverKey = await rootClient.query(
       query.CreateKey({ database: dbRef, role: 'server' })
     )
-    const adminKey = await rootClient.query(
+    adminKey = await rootClient.query(
       query.CreateKey({ database: dbRef, role: 'admin' })
     )
 
@@ -2763,39 +2765,9 @@ describe('query', () => {
     expect(currentIdentity).toBeFalsy()
   })
 
-  test('current_token returns object with AccessProvider', async () => {
-    const roleOneName = util.randomString('role_one_')
-    const issuerName = util.randomString('issuer_')
-    const providerName = util.randomString('provider_')
-    const jwksUri = util.randomString()
-    const fullUri = `https://${jwksUri}.auth0.com`
-
-    // Create Role
-    await adminClient.query(
-      query.CreateRole({
-        name: roleOneName,
-        privileges: [
-          {
-            resource: query.Databases(),
-            actions: { read: true },
-          },
-        ],
-      })
-    )
-
-    // Create AccessProvider
-    await adminClient.query(
-      query.CreateAccessProvider({
-        name: providerName,
-        issuer: issuerName,
-        jwks_uri: fullUri,
-        membership: [query.Role(roleOneName)],
-      })
-    )
-
-    // Retrieve Ref
+  test('current_token returns proper token', async () => {
     const currentToken = await adminClient.query(query.CurrentToken())
-    expect(currentToken).toBeInstanceOf(Object)
+    expect(currentToken).toEqual(adminKey.ref)
   })
 
   test('current_token fails when unauthenticated', async () => {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2779,36 +2779,7 @@ describe('query', () => {
   })
 
   test('has_current_token returns true when token present', async () => {
-    const roleOneName = util.randomString('role_one_')
-    const issuerName = util.randomString('issuer_')
-    const providerName = util.randomString('provider_')
-    const jwksUri = util.randomString()
-    const fullUri = `https://${jwksUri}.auth0.com`
-
-    // Create Role
-    await adminClient.query(
-      query.CreateRole({
-        name: roleOneName,
-        privileges: [
-          {
-            resource: query.Databases(),
-            actions: { read: true },
-          },
-        ],
-      })
-    )
-
-    // Create AccessProvider
-    await adminClient.query(
-      query.CreateAccessProvider({
-        name: providerName,
-        issuer: issuerName,
-        jwks_uri: fullUri,
-        membership: [query.Role(roleOneName)],
-      })
-    )
-
-    const hasCurrentToken = adminClient.query(query.HasCurrentToken())
+    const hasCurrentToken = await adminClient.query(query.HasCurrentToken())
     expect(hasCurrentToken).toBeTruthy()
   })
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2708,17 +2708,43 @@ describe('query', () => {
     }
   })
 
-  // TODO Create tests once work is done in Core
-  test.skip('current_identity', () => {})
+  // API v4 AccessProvider functions
 
-  // TODO Add test once Core work has been done
-  test.skip('has_current_identity', () => {})
+  test.skip('current_identity returns sub field from JWT', async () => {})
 
-  // TODO Finish test after Core work is done
-  test.skip('current_token', () => {})
+  test.only('current_identity fails when no identity present', async () => {
+    try {
+      await adminClient.query(query.CurrentIdentity())
+    } catch (err) {
+      expect(err).toBeInstanceOf(errors.BadRequest)
+    }
+  })
 
-  // TODO Define test once Core work is done
-  test.skip('has_current_token', () => {})
+  test.skip('has_current_identity returns true when identity present', async () => {})
+
+  test.only('has_current_identity returns false without identity present', async () => {
+    const currentIdentity = await adminClient.query(query.HasCurrentIdentity())
+    expect(currentIdentity).toBeFalsy()
+  })
+
+  test.skip('current_token returns Ref or object', () => {})
+
+  test.only('current_token fails when unauthenticated', async () => {
+    try {
+      await adminClient.query(query.CurrentToken())
+    } catch (err) {
+      expect(err).toBeInstanceOf(errors.BadRequest)
+    }
+  })
+
+  test.skip('has_current_token returns true when token present', () => {})
+
+  test.only('has_current_token returns false when no token present', async () => {
+    const hasCurrentToken = await adminClient.query(query.HasCurrentIdentity())
+    expect(hasCurrentToken).toBeFalsy()
+  })
+
+  // Test versioned queries/lambdas
 
   test('legacy queries/lambdas have default api_version', async () => {
     const res = await client.query(


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-788)

This PR adds tests for the following functions now that Core has implemented all the new FQL functionality:
- `CurrentToken`
- `HasCurrentToken`
- `CurrentIdentity`
- `HasCurrentIdentity`

### How to test
Run `npm run test` with the latest nightly Docker image