### PR TITLE
FE-586 | Add queryTimeout to QueryOptions type

### DIFF
--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -17,6 +17,7 @@ export interface ClientConfig {
 
 export interface QueryOptions {
   secret?: string
+  queryTimeout?: number
 }
 
 export default class Client {


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-586)

This PR addresses issue #275 reported by one of our users.

Essentially, when we added per-query timeouts as an option, we did not add the new `queryTimeout` field to the `QueryOptions` type. This fixes that.