### PR TITLE
FE-804 | fix: change Basic to Bearer in Authorization header call

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -260,7 +260,7 @@ function defaults(obj, def) {
 }
 
 function secretHeader(secret) {
-  return 'Basic ' + btoa(secret + ':')
+  return 'Bearer ' + btoa(secret + ':')
 }
 
 function responseHeadersAsObject(response) {

--- a/src/Client.js
+++ b/src/Client.js
@@ -2,7 +2,6 @@
 
 var APIVersion = '4'
 
-var btoa = require('btoa-lite')
 var errors = require('./errors')
 var query = require('./query')
 var values = require('./values')
@@ -260,7 +259,7 @@ function defaults(obj, def) {
 }
 
 function secretHeader(secret) {
-  return 'Bearer ' + btoa(secret + ':')
+  return 'Bearer ' + secret
 }
 
 function responseHeadersAsObject(response) {


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-804)

While testing out the preview of API v4, @fauna-brecht ran into an issue where he was receiving an `Unauthorized` response. @marrony determined this was due to us using `Basic` in our Authorization header instead of `Bearer`.