### PR TITLE
chore: bump to 4.0.0-preview.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "4.0.0-preview",
+  "version": "4.0.0-preview.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "3.0.1",
+  "version": "4.0.0-preview",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "4.0.0-preview",
+  "version": "4.0.0-preview.1",
   "description": "FaunaDB Javascript driver for Node.JS and Browsers",
   "homepage": "https://fauna.com",
   "repository": "fauna/faunadb-js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "3.0.1",
+  "version": "4.0.0-preview",
   "description": "FaunaDB Javascript driver for Node.JS and Browsers",
   "homepage": "https://fauna.com",
   "repository": "fauna/faunadb-js",


### PR DESCRIPTION
### Notes

This PR bumps the `version` in our `package.json` and `package-lock.json` from `3.0.1` to `4.0.0-preview` in preparation for publishing the API v4 preview to NPM 🚀