### PR TITLE
FE-815 | Update AccessProviders 'membership' field to 'roles'

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -1032,7 +1032,7 @@ function CreateRole(params) {
  *     - name: A valid schema name
  *     - issuer: A unique string
  *     - jwks_uri: A valid HTTPS URI
- *     - membership: An array of role/predicate pairs where the predicate returns a boolean.
+ *     - roles: An array of role/predicate pairs where the predicate returns a boolean.
  *                   The array can also contain Role references.
  * @return {Expr}
  */

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -901,7 +901,7 @@ describe('query', () => {
         name: providerName,
         issuer: issuerName,
         jwks_uri: fullUri,
-        membership: [
+        roles: [
           query.Role(roleOneName),
           {
             role: query.Role(`${roleTwoName}`),
@@ -914,7 +914,7 @@ describe('query', () => {
     expect(provider.name).toEqual(providerName)
     expect(provider.issuer).toEqual(issuerName)
     expect(provider.jwks_uri).toEqual(fullUri)
-    expect(provider.membership).toBeInstanceOf(Array)
+    expect(provider.roles).toBeInstanceOf(Array)
   })
 
   test('create_access_provider fails with non-unique issuer', async () => {
@@ -943,7 +943,7 @@ describe('query', () => {
         name: providerName,
         issuer: issuerName,
         jwks_uri: fullUri,
-        membership: [query.Role(roleOneName)],
+        roles: [query.Role(roleOneName)],
       })
     )
 
@@ -954,7 +954,7 @@ describe('query', () => {
           name: 'duplicate_provider',
           issuer: issuerName,
           jwks_uri: 'https://db.fauna.com',
-          membership: [query.Role(roleOneName)],
+          roles: [query.Role(roleOneName)],
         })
       )
     } catch (err) {
@@ -988,7 +988,7 @@ describe('query', () => {
           name: providerName,
           issuer: null,
           jwks_uri: fullUri,
-          membership: [query.Role(roleOneName)],
+          roles: [query.Role(roleOneName)],
         })
       )
     } catch (err) {
@@ -1021,7 +1021,7 @@ describe('query', () => {
         query.CreateAccessProvider({
           issuer: issuerName,
           jwks_uri: fullUri,
-          membership: [query.Role(roleOneName)],
+          roles: [query.Role(roleOneName)],
         })
       )
     } catch (err) {
@@ -1055,7 +1055,7 @@ describe('query', () => {
           name: providerName,
           issuer: issuerName,
           jwks_uri: jwksUri,
-          membership: [query.Role(roleOneName)],
+          roles: [query.Role(roleOneName)],
         })
       )
     } catch (err) {


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-815)

For AccessProviders, we decided to change the `membership` field to be called `roles` as this is more clear and self-documenting for the user.

### How to test
~**NOTE:** These unit tests will not pass until we have an updated Docker image of Core that has also implemented these changes~

Cannot merge this until the Core image has streaming enabled by default -- until then tests won't pass.