### PR TITLE
release: 4.0.0-preview.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "4.0.0-preview.1",
+  "version": "4.0.0-preview.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "4.0.0-preview.1",
+  "version": "4.0.0-preview.2",
   "description": "FaunaDB Javascript driver for Node.JS and Browsers",
   "homepage": "https://fauna.com",
   "repository": "fauna/faunadb-js",


### PR DESCRIPTION
### Notes
Bump the JS Driver to `4.0.0-preview.2`, so folks can continue using our new Streaming features with the Preview environment