### PR TITLE
Update CHANGELOG for v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.0.0
+
+- Adds AccessProvider() support for authenticating with external auth providers (ex. Auth0, Okta)
+- Adds beta support for event streaming
+- Adds new FQL functions: CreateAccessProvider(), AccessProviders(), AccessProvider(), CurrentIdentity(), and HasCurrentIdentity()
+- Deprecates Identity() function in favor of CurrentIdentity()
+- Deprecates HasIdentity() in favor of HasCurrentIdentity()
+
 ## 3.0.0
 
 - Added an alias of the Contains function called ContainsPath, and deprecated the Contains function.


### PR DESCRIPTION
### Notes

When we released `v4.0.0` today, the release pipeline didn't properly generate the CHANGELOG. This PR fixes that 👍