### PR TITLE
Improve Typescript definitions and fix a date test

### DIFF
--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -12,6 +12,7 @@ export interface ClientConfig {
   scheme?: 'http' | 'https'
   port?: number
   timeout?: number
+  queryTimeout?: number
   observer?: (res: RequestResult, client: Client) => void
   keepAlive?: boolean
   headers?: { [key: string]: string | number }

--- a/src/types/errors.d.ts
+++ b/src/types/errors.d.ts
@@ -6,6 +6,7 @@ export module errors {
 
     name: string
     message: string
+    description: string
   }
 
   export class InvalidValue extends FaunaError {}

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -83,7 +83,7 @@ describe('Values', () => {
   })
 
   test('date', () => {
-    var test_date = new FaunaDate(new Date(1970, 0, 1))
+    var test_date = new FaunaDate(new Date(Date.UTC(1970, 0, 1)))
     var test_date_json = '{"@date":"1970-01-01"}'
     expect(json.toJSON(test_date)).toEqual(test_date_json)
     expect(json.parseJSON(test_date_json)).toEqual(test_date)


### PR DESCRIPTION
### Notes
Hi. I would like to add some tiny improvements.
The first commit adds tiny Typescript improvements.

The second commit fixes a Test. 
As I live in Germany my Timezone is UTC+1. `new Date(1970, 0, 1)` will result in "1969-12-31T23:00:00.000Z" which won't match with "1970-01-01 ..." so that test failed on my machine. 

### How to test
same as usual :)