### PR TITLE
Fix for stringification to FQL which inserted nulls for zero-argument AND expose toFQL

### DIFF
--- a/src/Expr.js
+++ b/src/Expr.js
@@ -19,6 +19,10 @@ Expr.prototype.toJSON = function() {
   return this.raw
 }
 
+Expr.prototype.toFQL = function() {
+  return exprToString(this.raw)
+}
+
 var varArgsFunctions = [
   'Do',
   'Call',

--- a/src/Expr.js
+++ b/src/Expr.js
@@ -275,16 +275,13 @@ var exprToString = function(expr, caller) {
   var fn = keys[0]
   fn = convertToCamelCase(fn)
 
-  var args = []
-
-  keys.forEach(function(k) {
-    var v = expr[k]
-    if (v !== null) {
-      args.push(exprToString(v, fn))
-    }
-  })
-
-  args = args.join(', ')
+  // The filter prevents zero arity functions from having a null argument
+  // This only works under the assumptions
+  // that there are no functions where a single 'null' argument makes sense.
+  var args = keys
+    .filter(k => expr[k] !== null || keys.length > 1)
+    .map(k => exprToString(expr[k], fn))
+    .join(', ')
 
   return fn + '(' + args + ')'
 }

--- a/src/Expr.js
+++ b/src/Expr.js
@@ -271,9 +271,13 @@ var exprToString = function(expr, caller) {
   var fn = keys[0]
   fn = convertToCamelCase(fn)
 
-  var args = keys.map(function(k) {
+  var args = []
+
+  keys.forEach(function(k) {
     var v = expr[k]
-    return exprToString(v, fn)
+    if (v !== null) {
+      args.push(exprToString(v, fn))
+    }
   })
 
   args = args.join(', ')

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -406,11 +406,28 @@ describe('Values', () => {
       ),
       'Query(Lambda(["x", "y"], If(GT(Var("x"), Var("y")), "x > y", "x <= y")))'
     )
+    // Simple Select query
     assertPrint(
       new Query(
         q.Lambda('ref', q.Select(['data', 'name'], q.Get(q.Var('ref'))))
       ),
       'Query(Lambda("ref", Select(["data", "name"], Get(Var("ref")))))'
+    )
+
+    // Select with a default
+    assertPrint(
+      new Query(
+        q.Lambda('ref', q.Select(['data', 'name'], q.Get(q.Var('ref')), true))
+      ),
+      'Query(Lambda("ref", Select(["data", "name"], Get(Var("ref")), true)))'
+    )
+
+    // Select with null as a default default
+    assertPrint(
+      new Query(
+        q.Lambda('ref', q.Select(['data', 'name'], q.Get(q.Var('ref')), null))
+      ),
+      'Query(Lambda("ref", Select(["data", "name"], Get(Var("ref")), null)))'
     )
 
     //returns object
@@ -565,8 +582,18 @@ describe('Values', () => {
       'Query(Foreach([1, 2, 3], Lambda("i", Equals(0, Modulo(Var("i"), 2)))))'
     )
 
-    // now expr
+    // zero arity functions.
     assertPrint(new Query(q.Now()), 'Query(Now())')
+    assertPrint(new Query(q.Identity()), 'Query(Identity())')
+    assertPrint(new Query(q.Keys()), 'Query(Keys())')
+    assertPrint(new Query(q.Tokens()), 'Query(Tokens())')
+    assertPrint(new Query(q.AccessProviders()), 'Query(AccessProviders())')
+    assertPrint(new Query(q.Collections()), 'Query(Collections())')
+    assertPrint(new Query(q.Databases()), 'Query(Databases())')
+    assertPrint(new Query(q.Indexes()), 'Query(Indexes())')
+    assertPrint(new Query(q.Functions()), 'Query(Functions())')
+    assertPrint(new Query(q.Roles()), 'Query(Roles())')
+    assertPrint(new Query(q.NewId()), 'Query(NewId())')
   })
 
   test('pretty print Expr with primitive types', () => {

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -564,6 +564,9 @@ describe('Values', () => {
       ),
       'Query(Foreach([1, 2, 3], Lambda("i", Equals(0, Modulo(Var("i"), 2)))))'
     )
+
+    // now expr
+    assertPrint(new Query(q.Now()), 'Query(Now())')
   })
 
   test('pretty print Expr with primitive types', () => {

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -83,7 +83,7 @@ describe('Values', () => {
   })
 
   test('date', () => {
-    var test_date = new FaunaDate(new Date(1970, 0, 1))
+    var test_date = new FaunaDate(new Date(Date.UTC(1970, 0, 1)))
     var test_date_json = '{"@date":"1970-01-01"}'
     expect(json.toJSON(test_date)).toEqual(test_date_json)
     expect(json.parseJSON(test_date_json)).toEqual(test_date)


### PR DESCRIPTION
### Notes
This is related to this ticket:
[Jira Ticket](https://faunadb.atlassian.net/jira/software/c/projects/FE/issues/FE-642)

### Disclaimers
The code changes makes it possible for me to continue working, I'm currently working with a fork of this driver, do please check whether it doesn't break something else since I do not have that background on how the driver works. The PR is mainly here to  show where the problem is for the related ticket.
 
I have also exposed a function toFQL which I need for tooling. Feel free to separate both issues and/or rename it, doing a separate pull request is probably overkill.
If you choose not to make something like toFQL public, let me know, I'll have to include a chunk of code from the driver then in my tool.  

