### PR TITLE
ENG-2431: Switch from contatenated to line-separated JSON

### DIFF
--- a/src/stream.js
+++ b/src/stream.js
@@ -115,6 +115,7 @@ StreamClient.prototype.subscribe = function() {
 
   var body = JSON.stringify(self._query)
   var startTime = Date.now()
+  var buffer = ''
 
   function handleResponse(response) {
     var endTime = Date.now()
@@ -156,9 +157,10 @@ StreamClient.prototype.subscribe = function() {
   }
 
   function onData(data) {
-    var events = json.parseJSONStreaming(data)
+    var result = json.parseJSONStreaming(buffer + data)
+    buffer = result.buffer
 
-    events.forEach(function(event) {
+    result.values.forEach(function(event) {
       if (event.txn !== undefined) {
         self._client.syncLastTxnTime(event.txn)
       }

--- a/test/_json.test.js
+++ b/test/_json.test.js
@@ -1,10 +1,31 @@
 const { parseJSONStreaming } = require('../src/_json')
 
 describe('parseJSONStreaming', () => {
-  test('mutiple JSON objects in a message', () => {
-    const jsonText = `{"event":"version","txnTS":1603314266030000,"data":{"ref":{"@ref":{"id":"279947947320279552","collection":{"@ref":{"id":"Status","collection":{"@ref":{"id":"collections"}}}}}},"ts":{"@ts":"2020-10-21T21:04:26.030Z"},"action":"update","new":{"data":{"foo":"bar","scores":[30,27,9]}}}}{"event":"version","txnTS":1603314266050000,"data":{"ref":{"@ref":{"id":"279947947320279552","collection":{"@ref":{"id":"Status","collection":{"@ref":{"id":"collections"}}}}}},"ts":{"@ts":"2020-10-21T21:04:26.050Z"},"action":"update","new":{"data":{"foo":"bar","scores":[31,27,9]}}}}`
-    const result = parseJSONStreaming(jsonText)
+  test('parse non-delimited JSON objects', () => {
+    const jsonText = `{"foo": "bar"}`
+    const { values, buffer } = parseJSONStreaming(jsonText)
+    expect(values).toEqual([{ foo: 'bar' }])
+    expect(buffer).toEqual('')
+  })
 
-    expect(result).toHaveLength(2)
+  test('parse line-delimited JSON objects', () => {
+    const jsonText = `{"foo": "bar"}\r\n{"baz": 42}\r\n`
+    const { values, buffer } = parseJSONStreaming(jsonText)
+    expect(values).toEqual([{ foo: 'bar' }, { baz: 42 }])
+    expect(buffer).toEqual('')
+  })
+
+  test('parse partially delievered JSON objects', () => {
+    const jsonText = `{"foo": "bar"}\r\n{"baz`
+    const { values, buffer } = parseJSONStreaming(jsonText)
+    expect(values).toEqual([{ foo: 'bar' }])
+    expect(buffer).toEqual(`{"baz`)
+  })
+
+  test.only('ignore leading new line', () => {
+    const jsonText = `\r\n{"foo": "bar"}\r\n{"baz`
+    const { values, buffer } = parseJSONStreaming(jsonText)
+    expect(values).toEqual([{ foo: 'bar' }])
+    expect(buffer).toEqual(`{"baz`)
   })
 })

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -221,6 +221,31 @@ describe('StreamAPI', () => {
         })
         .start()
     })
+
+    test('can listen to large events', done => {
+      var arr = []
+      for (let i = 0; i < 4096; i++) {
+        // at least 4KB
+        arr.push({ value: i.toString() })
+      }
+
+      stream = client
+        .stream(doc.ref)
+        .on('start', () => {
+          client.query(
+            q.Update(doc.ref, {
+              data: {
+                values: arr,
+              },
+            })
+          )
+        })
+        .on('version', evt => {
+          expect(evt.document.data.values).toEqual(arr)
+          done()
+        })
+        .start()
+    })
   })
 
   describe('document', () => {


### PR DESCRIPTION
### Notes
To support for large JSON documents, we're moving from concatenated JSON objects to line-separated JSON streaming. This fix is intended to be backwards compatible while supporting the new line-separated format that is coming to cloud soon.

### How to test

With a recent nightly build: 

* Create a document;
* Open a stream for it;
* Issue an updated with a relatively large JSON document (about 4KB or more).

Without this fix, the JSON parsing on the received version should break. With this path, you shall receive the updated version normally as part of the document stream.

We should release this fix once ENG-2431 is in cloud.