### PR TITLE
Fix FaunaDate test to ignore timezone

### DIFF
--- a/test/values.test.js
+++ b/test/values.test.js
@@ -83,7 +83,7 @@ describe('Values', () => {
   })
 
   test('date', () => {
-    var test_date = new FaunaDate(new Date(1970, 0, 1))
+    var test_date = new FaunaDate(new Date(Date.UTC(1970, 0, 1)))
     var test_date_json = '{"@date":"1970-01-01"}'
     expect(json.toJSON(test_date)).toEqual(test_date_json)
     expect(json.parseJSON(test_date_json)).toEqual(test_date)


### PR DESCRIPTION
### Notes
Test "Values › date" doesn't respect timezone

### Actual result
```
Values › date

    expect(received).toEqual(expected) // deep equality

    Expected: "{\"@date\":\"1970-01-01\"}"
    Received: "{\"@date\":\"1969-12-31\"}"

      86 |     var test_date = new FaunaDate(new Date(1970, 0, 1))
      87 |     var test_date_json = '{"@date":"1970-01-01"}'
    > 88 |     expect(json.toJSON(test_date)).toEqual(test_date_json)
         |                                    ^
      89 |     expect(json.parseJSON(test_date_json)).toEqual(test_date)
      90 |   })
      91 | 

      at Object.test (test/values.test.js:88:36)
```

### Expected result
Test should be passed

### How to test
Set custom timezone (in my case GMT+3) and run test
```
jest --env=node --verbose=false ./test/values.test.js 
```