### PR TITLE
DRV-376 Fix request timeout

### DIFF
--- a/src/_http.js
+++ b/src/_http.js
@@ -4,6 +4,7 @@ var APIVersion = '4'
 
 var parse = require('url-parse')
 var util = require('./_util')
+var AbortController = require('abort-controller')
 
 /**
  * The driver's internal HTTP client.
@@ -88,14 +89,30 @@ HttpClient.prototype.execute = function(method, path, body, query, options) {
   headers['X-Last-Seen-Txn'] = this._lastSeen
   headers['X-Query-Timeout'] = queryTimeout
 
+  var timeout
+  if (!signal && this._timeout) {
+    var abortController = new AbortController()
+    signal = abortController.signal
+    timeout = setTimeout(function() {
+      abortController.abort()
+    }, this._timeout)
+  }
+
   return fetch(url.href, {
     agent: this._keepAliveEnabledAgent,
     body: body,
     signal: signal,
     headers: util.removeNullAndUndefinedValues(headers),
     method: method,
-    timeout: this._timeout,
   })
+    .then(function(response) {
+      clearTimeout(timeout)
+      return response
+    })
+    .catch(function(error) {
+      clearTimeout(timeout)
+      throw error
+    })
 }
 
 /** @ignore */

--- a/src/_http.js
+++ b/src/_http.js
@@ -93,9 +93,7 @@ HttpClient.prototype.execute = function(method, path, body, query, options) {
   if (!signal && this._timeout) {
     var abortController = new AbortController()
     signal = abortController.signal
-    timeout = setTimeout(function() {
-      abortController.abort()
-    }, this._timeout)
+    timeout = setTimeout(abortController.abort, this._timeout)
   }
 
   return fetch(url.href, {


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/DRV-376)
Current driver pass a 60 seconds timeout down to the `cross-fetch` polyfill. However, neither `whatwg-fetch` of `node-fetch` are aware of it. They both support abort signals, though: https://github.com/node-fetch/node-fetch#request-cancellation-with-abortsignal.

### Screenshots
![image](https://user-images.githubusercontent.com/12122603/104723792-72c17c00-5738-11eb-97a2-e53e52e556c3.png)
