### PR TITLE
DRV-369: get rid of util nodejs package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ dist
 !.vscode/launch.json
 !.vscode/extensions.json
 *.code-workspace
+.idea
 
 testConfig.json
 doc/

--- a/src/_util.js
+++ b/src/_util.js
@@ -1,6 +1,43 @@
 'use strict'
 
 /**
+ * Inherit the prototype methods from one constructor into another.
+ * Source: https://github.com/kaelzhang/node-util-inherits
+ * @param {function} ctor Constructor function which needs to inherit the prototype.
+ * @param {function} superCtor Constructor function to inherit prototype from.
+ * @private
+ */
+function inherits(ctor, superCtor) {
+  if (ctor === undefined || ctor === null) {
+    throw new TypeError(
+      'The constructor to "inherits" must not be null or undefined'
+    )
+  }
+
+  if (superCtor === undefined || superCtor === null) {
+    throw new TypeError(
+      'The super constructor to "inherits" must not be null or undefined'
+    )
+  }
+
+  if (superCtor.prototype === undefined) {
+    throw new TypeError(
+      'The super constructor to "inherits" must have a prototype'
+    )
+  }
+
+  ctor.super_ = superCtor
+  ctor.prototype = Object.create(superCtor.prototype, {
+    constructor: {
+      value: ctor,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    },
+  })
+}
+
+/**
  * Determines if the current environment is a NodeJS environment.
  * @private
  */
@@ -87,6 +124,7 @@ function checkInstanceHasProperty(obj, prop) {
 }
 
 module.exports = {
+  inherits: inherits,
   isNodeEnv: isNodeEnv,
   defaults: defaults,
   applyDefaults: applyDefaults,

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var util = require('util')
+var util = require('./_util')
 
 /**
  * FaunaDB error types. Request errors can originate from the client (e.g. bad

--- a/src/values.js
+++ b/src/values.js
@@ -4,10 +4,11 @@ var base64 = require('base64-js')
 var deprecate = require('util-deprecate')
 var errors = require('./errors')
 var Expr = require('./Expr')
-var util = require('util')
+var util = require('./_util')
+var nodeUtil = util.isNodeEnv() ? require('util') : null
 
-var customInspect = util && util.inspect && util.inspect.custom
-var stringify = (util && util.inspect) || JSON.stringify
+var customInspect = nodeUtil && nodeUtil.inspect.custom
+var stringify = nodeUtil ? nodeUtil.inspect : JSON.stringify
 
 /**
  * FaunaDB value types. Generally, these collections do not need to be instantiated


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/DRV-369)
NodeJS `util` package has been used for `.inherits` and `.inspect` functions. Current implementation supposes polyfilling `.inherits` function by created one in `src/_util.js` and optionally using `.inspect` only when we're running on NodeJS environment

### How to test
No features / fixes have been introduced. Can be tested regression-wise