### PR TITLE
DRV-365 handle stream end the same fashion as for browser

### DIFF
--- a/src/stream.js
+++ b/src/stream.js
@@ -184,6 +184,14 @@ StreamClient.prototype.subscribe = function() {
     }
   }
 
+  function onEnd() {
+    // Temporally fix to simulate the same behaviour as browser has with http2
+    self._onEvent({
+      type: 'error',
+      event: new TypeError('network error'),
+    })
+  }
+
   // Minimum browser compatibility based on current code:
   //   Chrome                52
   //   Edge                  79
@@ -200,7 +208,10 @@ StreamClient.prototype.subscribe = function() {
   function platformSpecificEventRead(response) {
     try {
       if (util.isNodeEnv()) {
-        response.body.on('data', onData).on('error', onError)
+        response.body
+          .on('data', onData)
+          .on('error', onError)
+          .on('end', onEnd)
       } else {
         // ATENTION: The following code is meant to run in browsers and is not
         // covered by current test automation. Manual testing on major browsers


### PR DESCRIPTION
### Notes
[Stream termination due to core's one-hour limit does not cause an error event](https://faunadb.atlassian.net/browse/DRV-365)

stream throw `end` event for nodejs and `error` event for the browser (tested at chrome). i suppose it would be a good idea if the driver will silently reconnect when such a case raised. 

to simulate the same behaviour as for browser, fix listen for `end` event and as soon as the event appears, fix convert it to an `error` event. 

### How to test
```
const faunadb = require('./index')
const q = faunadb.query
const util = require('util')

var client = new faunadb.Client({
  secret: 'XXXXXX'
})

;(async () => {
  await client.query(
  q.Paginate(q.Collections())
  )
  .then(ret => console.log(ret))
  .catch(err => console.error('Error: %s', err))
})()

var stream
function startStream() {
  stream = client.stream.document(q.Ref(q.Collection('Status'),
  '278763355019149825'))
  .on('snapshot', snapshot => {
    const m = util.inspect(snapshot, { showHidden: false, depth: null })
    console.log(m)
  })
  .on('version', version => {
    const m = util.inspect(version, { showHidden: false, depth: null })
    console.log(m)
    console.log(stream._client._state)
  })
  .on('error', error => console.error('Error: %s', error))
  .start()
}
```

### Screenshots