### PR TITLE
DRV-337 driver does not graciously fail when we go over the limit

### DIFF
--- a/src/stream.js
+++ b/src/stream.js
@@ -241,7 +241,7 @@ StreamClient.prototype.subscribe = function() {
   self._client._http
     .execute('POST', 'stream', body, self._urlParams, {
       fetch: self._fetch,
-      signal: self._abort.signal,
+      abortController: self._abort,
     })
     .then(function(response) {
       return handleResponse(response).then(function() {


### PR DESCRIPTION
### Notes
[driver does not graciously fail when we go over the limit](https://faunadb.atlassian.net/browse/DRV-337)
JS driver does not return errors when going over the stream limit.

Unfortunately, there is no evidence from the backend that we can relly and recognize that client faced to limit. backend just keep a connection in a pending state.

Currently, the issue happens only for the JS browser driver, however, as soon as http2 would be implemented for nodejs, we would be faced the same issue for nodejs as well. because of http2 multiplexing feature, the number of concurrent requests per domain is not limited to 6-8, but it is virtually unlimited. It is virtually unlimited in the sense that browsers and servers may limit the number of concurrent requests via the configuration parameter called SETTINGS_MAX_CONCURRENT_STREAMS. if it’s client settings, this means how many concurrent streams the client can handle it’s backend settings, this means how many concurrent streams the backend can accept. i haven’t found any change to increase this param as it’s specified in the source code of browsers. however, i found that the backend has the following settings MAX_CONCURRENT_STREAMS = 100, probably we can increase it and check if requests are stuck or not. 

Anyway, JS driver has to throw an error for such a case, the workaround would be using the same approach with the abort controller as for queries. basically, it aborts request by timeout. 


### How to test
Sample code
```javascript
var client = new faunadb.Client({
  secret: 'your secret',
  timeout: 5
})

function startStream() {
  stream = client.stream.document(q.Ref(q.Collection('users'),'282652881944838658'))
  .on('snapshot', snapshot => {
    console.log('snapshot')
    startStream()
  })
  .on('version', version => {
    console.log('version')
  })
  .on('error', error => console.error('Error: %s', error))
  .start()
}

startStream()
```
The expected result would be an error when the number of open streams rich limit. Also good to test that 1 open stream is not aborted by timeout