### PR TITLE
chore: Added tests to reflect the error event delegation

### DIFF
--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -155,8 +155,8 @@ describe('StreamAPI', () => {
 
     test('wraps delegated error events if stream closed unexpectedly', async done => {
       testErrorEvent(done, error => {
-        if (error.code === undefined) {
-          expect(error.name).toEqual('TypeError')
+        if (error instanceof TypeError) {
+          expect(error.message).toEqual('network error')
         }
       })
     })

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -113,7 +113,7 @@ describe('StreamAPI', () => {
       expect(() => stream.start()).toThrow(Error)
     })
 
-    test('wraps error events', async done => {
+    async function testErrorEvent(done, checkErrorCallback) {
       let role = await client.query(
         q.CreateRole({
           name: util.randomString('role'),
@@ -136,13 +136,29 @@ describe('StreamAPI', () => {
           await client.query(q.Update(doc.ref, {}))
         })
         .on('error', error => {
+          checkErrorCallback(error)
+          done()
+        })
+        .start()
+    }
+
+    test('wraps error events', async done => {
+      testErrorEvent(done, error => {
+        if (error.code && error.description) {
           expect(error.code).toEqual('permission denied')
           expect(error.description).toEqual(
             'Authorization lost during stream evaluation.'
           )
-          done()
-        })
-        .start()
+        }
+      })
+    })
+
+    test('wraps delegated error events if stream closed unexpectedly', async done => {
+      testErrorEvent(done, error => {
+        if (error.code === undefined) {
+          expect(error.name).toEqual('TypeError')
+        }
+      })
     })
 
     test('reports to client observer', done => {


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/DRV-444)

### How to test
This fix doesn't introduce any changes to the client code, but rather adds missing tests to reflect that if there is an unexpected error in opened stream connection happened, we have 2 errors sent to the client: from onError and onEnd events.