### PR TITLE
Use abortcontroller polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1341,13 +1341,10 @@
       "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
       "dev": true
     },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
+    "abortcontroller-polyfill": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.1.tgz",
+      "integrity": "sha512-yml9NiDEH4M4p0G4AcPkg8AAa4mF3nfYF28VQxaokpO67j9H7gWgmsVWJ/f1Rn+PzsnDYvzJzWIQzCqDKRvWlA=="
     },
     "acorn": {
       "version": "7.1.1",
@@ -3462,11 +3459,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
-    },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "events": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "types": "index.d.ts",
   "dependencies": {
-    "abort-controller": "^3.0.0",
+    "abortcontroller-polyfill": "^1.7.1",
     "base64-js": "^1.2.0",
     "btoa-lite": "^1.0.0",
     "cross-fetch": "^3.0.6",

--- a/src/_http.js
+++ b/src/_http.js
@@ -4,7 +4,10 @@ var APIVersion = '4'
 
 var parse = require('url-parse')
 var util = require('./_util')
-var AbortController = require('abort-controller')
+var {
+  AbortController,
+  abortableFetch,
+} = require('abortcontroller-polyfill/dist/cjs-ponyfill')
 
 /**
  * The driver's internal HTTP client.
@@ -20,7 +23,7 @@ function HttpClient(options) {
     options.port = isHttps ? 443 : 80
   }
 
-  this._fetch = resolveFetch(options.fetch, true)
+  this._fetch = abortableFetch(resolveFetch(options.fetch, true)).fetch
   this._baseUrl = options.scheme + '://' + options.domain + ':' + options.port
   this._timeout = Math.floor(options.timeout * 1000)
   this._secret = options.secret

--- a/src/_http.js
+++ b/src/_http.js
@@ -23,7 +23,7 @@ function HttpClient(options) {
     options.port = isHttps ? 443 : 80
   }
 
-  this._fetch = abortableFetch(resolveFetch(options.fetch, true)).fetch
+  this._fetch = resolveFetch(options.fetch, true)
   this._baseUrl = options.scheme + '://' + options.domain + ':' + options.port
   this._timeout = Math.floor(options.timeout * 1000)
   this._secret = options.secret
@@ -96,7 +96,7 @@ HttpClient.prototype.execute = function(method, path, body, query, options) {
   if (!signal && this._timeout) {
     var abortController = new AbortController()
     signal = abortController.signal
-    timeout = setTimeout(abortController.abort, this._timeout)
+    timeout = setTimeout(() => abortController.abort(), this._timeout)
   }
 
   return fetch(url.href, {
@@ -179,9 +179,10 @@ function resolveFetch(fetchOverride, preferPolyfill) {
   }
 
   if (delegate !== null) {
+    var abortableDelegate = abortableFetch(delegate).fetch
     var fetch = function() {
       // NB. Rebinding to global is needed for Safari.
-      return delegate.apply(global, arguments)
+      return abortableDelegate.apply(global, arguments)
     }
     fetch.polyfill = true
     fetch.override = override

--- a/src/stream.js
+++ b/src/stream.js
@@ -12,7 +12,7 @@
 // visibility control. However, DO NOT change any internal state from outside of
 // its context as it'd most certainly lead to errors.
 
-var AbortController = require('abort-controller')
+var { AbortController } = require('abortcontroller-polyfill/dist/cjs-ponyfill')
 var RequestResult = require('./RequestResult')
 var errors = require('./errors')
 var http = require('./_http')

--- a/src/stream.js
+++ b/src/stream.js
@@ -12,7 +12,10 @@
 // visibility control. However, DO NOT change any internal state from outside of
 // its context as it'd most certainly lead to errors.
 
-var { AbortController } = require('abortcontroller-polyfill/dist/cjs-ponyfill')
+var {
+  AbortController,
+  abortableFetch,
+} = require('abortcontroller-polyfill/dist/cjs-ponyfill')
 var RequestResult = require('./RequestResult')
 var errors = require('./errors')
 var http = require('./_http')


### PR DESCRIPTION
### Notes
The issue can be reproduced if run faunadb-js at netlify functions.
Don't really know the root cause of this issue, but somehow related to CommonJS modules. Seems like netlify build stage use them rather then ES6 modules

### How to test
This [repo](https://github.com/fireridlle/fauna-express) can be used as a code example
run netlify functions locally
```
npx netlify-lambda serve api/
```

open at the browser http://localhost:9000/.netlify/functions/index/fauna
or for streaming http://localhost:9000/.netlify/functions/index/debug-fauna-stream (only nodejs console logs available here)

Getting an error
```
(node:16784) UnhandledPromiseRejectionWarning: TypeError: o is not a constructor
    at r.execute (/Users/szinkevych/projects/faunadb/fauna-express/functions/index.js:164:2194)
    at d._execute (/Users/szinkevych/projects/faunadb/fauna-express/functions/index.js:325:32329)
    at d.query (/Users/szinkevych/projects/faunadb/fauna-express/functions/index.js:325:31673)
```

### Screenshots