### PR TITLE
Decrease bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10868,11 +10868,6 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
-    "querystringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
-    },
     "quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -11170,11 +11165,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "requizzle": {
       "version": "0.2.3",
@@ -12924,15 +12914,6 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
-    },
-    "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "dotenv": "^8.2.0",
     "fn-annotate": "^1.1.3",
     "object-assign": "^4.1.0",
-    "url-parse": "^1.4.7",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
@@ -74,5 +73,11 @@
     "branches": [
       "master"
     ]
+  },
+  "browser": {
+    "http": false,
+    "https": false,
+    "os": false,
+    "util": false
   }
 }

--- a/src/_http.js
+++ b/src/_http.js
@@ -96,12 +96,6 @@ HttpClient.prototype.execute = function(method, path, body, query, options) {
     timeout = setTimeout(() => abortController.abort(), this._timeout)
   }
 
-  console.info('_baseUrl', this._baseUrl)
-  console.info('path', path)
-  console.info('query', query)
-
-  console.info('formtted ', formatUrl(this._baseUrl, path, query))
-
   return fetch(formatUrl(this._baseUrl, path, query), {
     agent: this._keepAliveEnabledAgent,
     body: body,

--- a/src/_http.js
+++ b/src/_http.js
@@ -2,12 +2,12 @@
 
 var APIVersion = '4'
 
-var parse = require('url-parse')
 var util = require('./_util')
 var {
   AbortController,
   abortableFetch,
 } = require('abortcontroller-polyfill/dist/cjs-ponyfill')
+const { formatUrl } = require('./_util')
 
 /**
  * The driver's internal HTTP client.
@@ -75,9 +75,6 @@ HttpClient.prototype.syncLastTxnTime = function(time) {
  * @returns {Promise} The response promise.
  */
 HttpClient.prototype.execute = function(method, path, body, query, options) {
-  var url = parse(this._baseUrl)
-  url.set('pathname', path)
-  url.set('query', query)
   options = util.defaults(options, {})
 
   var signal = options.signal
@@ -99,7 +96,13 @@ HttpClient.prototype.execute = function(method, path, body, query, options) {
     timeout = setTimeout(() => abortController.abort(), this._timeout)
   }
 
-  return fetch(url.href, {
+  console.info('_baseUrl', this._baseUrl)
+  console.info('path', path)
+  console.info('query', query)
+
+  console.info('formtted ', formatUrl(this._baseUrl, path, query))
+
+  return fetch(formatUrl(this._baseUrl, path, query), {
     agent: this._keepAliveEnabledAgent,
     body: body,
     signal: signal,

--- a/src/_util.js
+++ b/src/_util.js
@@ -123,7 +123,79 @@ function checkInstanceHasProperty(obj, prop) {
   return typeof obj === 'object' && obj !== null && Boolean(obj[prop])
 }
 
+function formatUrl(base, path, query) {
+  query = typeof query === 'object' ? querystringify(query) : query
+  return [
+    base,
+    path ? (path.charAt(0) === '/' ? '' : '/' + path) : '',
+    query ? (query.charAt(0) === '?' ? '' : '?' + query) : '',
+  ].join('')
+}
+
+/**
+ * Transform a query string to an object.
+ *
+ * @param {Object} obj Object that should be transformed.
+ * @param {String} prefix Optional prefix.
+ * @returns {String}
+ * @api public
+ */
+function querystringify(obj, prefix) {
+  prefix = prefix || ''
+
+  var pairs = [],
+    value,
+    key
+
+  //
+  // Optionally prefix with a '?' if needed
+  //
+  if ('string' !== typeof prefix) prefix = '?'
+
+  for (key in obj) {
+    if (checkInstanceHasProperty(obj, key)) {
+      value = obj[key]
+
+      //
+      // Edge cases where we actually want to encode the value to an empty
+      // string instead of the stringified value.
+      //
+      if (!value && (value === null || value === undef || isNaN(value))) {
+        value = ''
+      }
+
+      key = encode(key)
+      value = encode(value)
+
+      //
+      // If we failed to encode the strings, we should bail out as we don't
+      // want to add invalid strings to the query.
+      //
+      if (key === null || value === null) continue
+      pairs.push(key + '=' + value)
+    }
+  }
+
+  return pairs.length ? prefix + pairs.join('&') : ''
+}
+
+/**
+ * Attempts to encode a given input.
+ *
+ * @param {String} input The string that needs to be encoded.
+ * @returns {String|Null} The encoded string.
+ * @api private
+ */
+function encode(input) {
+  try {
+    return encodeURIComponent(input)
+  } catch (e) {
+    return null
+  }
+}
+
 module.exports = {
+  formatUrl: formatUrl,
   inherits: inherits,
   isNodeEnv: isNodeEnv,
   defaults: defaults,


### PR DESCRIPTION
don't inject http,https,os,utils polyfills. they are required only inside condition isNodeEnv, so we are safe to remove them from the browser bundle

extract from the heavy url-parse package only what we need


Before
![image](https://user-images.githubusercontent.com/12122603/106448318-4709fa00-648b-11eb-9747-18ce6502b62b.png)

After
![image](https://user-images.githubusercontent.com/12122603/106448345-4e310800-648b-11eb-8596-2bd1ce67d4f8.png)


Note: screenshots above were made from non minified bundle. minified bundle about 78KB.