### PR TITLE
DRV 356 recognize runtime env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1346,11 +1346,6 @@
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.1.tgz",
       "integrity": "sha512-yml9NiDEH4M4p0G4AcPkg8AAa4mF3nfYF28VQxaokpO67j9H7gWgmsVWJ/f1Rn+PzsnDYvzJzWIQzCqDKRvWlA=="
     },
-    "abortcontroller-polyfill": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.1.tgz",
-      "integrity": "sha512-yml9NiDEH4M4p0G4AcPkg8AAa4mF3nfYF28VQxaokpO67j9H7gWgmsVWJ/f1Rn+PzsnDYvzJzWIQzCqDKRvWlA=="
-    },
     "acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
@@ -1885,6 +1880,14 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
+    },
+    "browser-detect": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/browser-detect/-/browser-detect-0.2.28.tgz",
+      "integrity": "sha512-KeWGHqYQmHDkCFG2dIiX/2wFUgqevbw/rd6wNi9N6rZbaSJFtG5kel0HtprRwCGp8sqpQP79LzDJXf/WCx4WAw==",
+      "requires": {
+        "core-js": "^2.5.7"
+      }
     },
     "browser-pack": {
       "version": "6.1.0",
@@ -2586,6 +2589,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1349,6 +1349,11 @@
         "event-target-shim": "^5.0.0"
       }
     },
+    "abortcontroller-polyfill": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.1.tgz",
+      "integrity": "sha512-yml9NiDEH4M4p0G4AcPkg8AAa4mF3nfYF28VQxaokpO67j9H7gWgmsVWJ/f1Rn+PzsnDYvzJzWIQzCqDKRvWlA=="
+    },
     "acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "faunadb",
   "version": "4.0.0",
+  "apiVersion": "4",
   "description": "FaunaDB Javascript driver for Node.JS and Browsers",
   "homepage": "https://fauna.com",
   "repository": "fauna/faunadb-js",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "types": "index.d.ts",
   "dependencies": {
     "abort-controller": "^3.0.0",
+    "abortcontroller-polyfill": "^1.7.1",
     "base64-js": "^1.2.0",
     "btoa-lite": "^1.0.0",
     "cross-fetch": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "abortcontroller-polyfill": "^1.7.1",
     "base64-js": "^1.2.0",
+    "browser-detect": "^0.2.28",
     "btoa-lite": "^1.0.0",
     "cross-fetch": "^3.0.6",
     "dotenv": "^8.2.0",

--- a/src/_http.js
+++ b/src/_http.js
@@ -101,12 +101,10 @@ HttpClient.prototype.execute = function(method, path, body, query, options) {
     method: method,
   })
     .then(function(response) {
-      console.info('fetch success')
       clearTimeout(timeout)
       return response
     })
     .catch(function(error) {
-      console.info('fetch error')
       clearTimeout(timeout)
       throw error
     })

--- a/src/_http.js
+++ b/src/_http.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var pjson = require('../package.json')
-var parse = require('url-parse')
 var util = require('./_util')
 var {
   AbortController,
@@ -86,9 +85,6 @@ HttpClient.prototype.execute = function(method, path, body, query, options) {
   headers['Authorization'] = secret && secretHeader(secret)
   headers['X-Last-Seen-Txn'] = this._lastSeen
   headers['X-Query-Timeout'] = queryTimeout
-
-  console.debug('request headers for test ')
-  console.debug(headers)
 
   var timeout
   if (!signal && this._timeout) {

--- a/src/_http.js
+++ b/src/_http.js
@@ -33,10 +33,10 @@ function HttpClient(options) {
   // via `this._headers = util.applyDefaults` for browser as well
   if (util.isNodeEnv()) {
     this._headers['X-Fauna-Driver-Version'] = pjson.version
-    this._headers['X-Runtime-Environment'] = getNodeRuntimeEnv()
-    // util.isNodeEnv()
-    //   ? getNodeRuntimeEnv()
-    //   : navigator.userAgent,
+    this._headers['X-Runtime-Environment'] = util.isNodeEnv()
+      ? getNodeRuntimeEnv()
+      : navigator.userAgent
+    this._headers['X-NodeJS-Version'] = process.version
   }
 
   this._queryTimeout = options.queryTimeout
@@ -270,12 +270,7 @@ function getNodeRuntimeEnv() {
   ]
 
   var detectedEnv = runtimeEnvs.find(env => env.check())
-
-  return [
-    detectedEnv ? detectedEnv.name : 'Unknown environment',
-    'NodeJs@' + process.version,
-    require('os').platform(),
-  ].join(', ')
+  return detectedEnv ? detectedEnv.name : require('os').platform()
 }
 
 module.exports = {

--- a/src/_http.js
+++ b/src/_http.js
@@ -3,7 +3,7 @@
 var parse = require('url-parse')
 var util = require('./_util')
 var pjson = require('../package.json')
-var AbortController = require('abort-controller')
+var { AbortController } = require('abort-controller')
 
 /**
  * The driver's internal HTTP client.

--- a/src/_http.js
+++ b/src/_http.js
@@ -3,7 +3,7 @@
 var parse = require('url-parse')
 var util = require('./_util')
 var pjson = require('../package.json')
-var { AbortController } = require('abort-controller')
+var AbortController = require('abort-controller')
 
 /**
  * The driver's internal HTTP client.
@@ -108,7 +108,7 @@ HttpClient.prototype.execute = function(method, path, body, query, options) {
   var timeout
   if (!signal && this._timeout) {
     console.debug('11', AbortController)
-    var abortController = new AbortController()
+    var abortController = new AbortController.AbortController()
     console.debug('22')
     signal = abortController.signal
     console.debug('33')

--- a/src/_http.js
+++ b/src/_http.js
@@ -3,7 +3,7 @@
 var parse = require('url-parse')
 var util = require('./_util')
 var pjson = require('../package.json')
-var AbortController = require('abort-controller')
+var { AbortController } = require('abortcontroller-polyfill/dist/cjs-ponyfill')
 
 /**
  * The driver's internal HTTP client.
@@ -108,7 +108,7 @@ HttpClient.prototype.execute = function(method, path, body, query, options) {
   var timeout
   if (!signal && this._timeout) {
     console.debug('11', AbortController)
-    var abortController = new AbortController.AbortController()
+    var abortController = new AbortController()
     console.debug('22')
     signal = abortController.signal
     console.debug('33')

--- a/src/_http.js
+++ b/src/_http.js
@@ -106,9 +106,14 @@ HttpClient.prototype.execute = function(method, path, body, query, options) {
 
   var timeout
   if (!signal && this._timeout) {
+    console.debug('11', AbortController)
     var abortController = new AbortController()
+    console.debug('22')
     signal = abortController.signal
-    timeout = setTimeout(abortController.abort, this._timeout)
+    console.debug('33')
+    timeout = setTimeout(() => {
+      abortController.abort()
+    }, this._timeout)
   }
 
   console.debug('before fetch')

--- a/src/_http.js
+++ b/src/_http.js
@@ -111,6 +111,8 @@ HttpClient.prototype.execute = function(method, path, body, query, options) {
     timeout = setTimeout(abortController.abort, this._timeout)
   }
 
+  console.debug('before fetch')
+  console.debug(util.removeNullAndUndefinedValues(headers))
   return fetch(url.href, {
     agent: this._keepAliveEnabledAgent,
     body: body,

--- a/src/_http.js
+++ b/src/_http.js
@@ -101,9 +101,10 @@ HttpClient.prototype.execute = function(method, path, body, query, options) {
   headers['X-Last-Seen-Txn'] = this._lastSeen
   headers['X-Query-Timeout'] = queryTimeout
 
-  console.debug('request headers for ')
+  console.debug('request headers for test ')
   console.debug(headers)
 
+  console.debug('0000')
   var timeout
   if (!signal && this._timeout) {
     console.debug('11', AbortController)

--- a/src/_http.js
+++ b/src/_http.js
@@ -217,7 +217,10 @@ function getDefaultHeaders() {
   return headers
 }
 
-/** @ignore */
+/**
+ * For checking process.env always use `hasOwnProperty`
+ * Some providers could throw an error when trying to access env variables that does not exists
+ * @ignore */
 function getNodeRuntimeEnv() {
   var runtimeEnvs = [
     {

--- a/src/_http.js
+++ b/src/_http.js
@@ -230,7 +230,9 @@ function getNodeRuntimeEnv() {
     },
     {
       name: 'Heroku',
-      check: () => process.env.PATH.indexOf('.heroku') !== -1,
+      check: () =>
+        process.env.hasOwnProperty('PATH') &&
+        process.env.PATH.indexOf('.heroku') !== -1,
     },
     {
       name: 'AWS Lambda',
@@ -239,7 +241,7 @@ function getNodeRuntimeEnv() {
     {
       name: 'GCP Cloud Functions',
       check: () =>
-        process.env.hasOwnProperty('FUNCTION_TARGET') &&
+        process.env.hasOwnProperty('_') &&
         process.env._.indexOf('google') !== -1,
     },
     {
@@ -254,8 +256,9 @@ function getNodeRuntimeEnv() {
     {
       name: 'Azure Compute',
       check: () =>
-        process.env.ORYX_ENV_TYPE === 'AppService' &&
-        process.env.WEBSITE_INSTANCE_ID,
+        process.env.hasOwnProperty('ORYX_ENV_TYPE') &&
+        process.env.hasOwnProperty('WEBSITE_INSTANCE_ID') &&
+        process.env.ORYX_ENV_TYPE === 'AppService',
     },
     {
       name: 'Worker',


### PR DESCRIPTION
### Notes
[DRV-356](https://faunadb.atlassian.net/browse/DRV-356)

New headers applied for each request.

## For NodeJS env
**X-Fauna-Driver-Version**
faunadb-js version (taken from package.json)
**X-Runtime-Environment**
name of runtime env (ex: Netlify, Vercel, etc..) or Unknown for an environment that can't be recognizable
**X-Runtime-Environment-OS**
Name of OS (ex: darwin, linux)
**X-NodeJS-Version**
Version of NodeJS

## For browser
Currently disabled due to CORS error

**X-Fauna-Driver-Version**
faunadb-js version (taken from package.json)
**X-Runtime-Environment**
Browser name
**X-Runtime-Environment-Version**
Browser version
**X-Runtime-Environment-OS**
Name of OS (ex: darwin, linux)