### PR TITLE
Revert abort controller and more sophisticated nodejs env detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,11 +246,11 @@ const client = new faunadb.Client({
 
 ### Using with Cloudflare Workers
 
-Cloudflare Workers has neither XMLHttpRequest nor fetch in global scope.
-Therefore, cross-fetch package is unable to inject fetch, and throws an error.
-fetch function is injected via closure, so the workaround would be to pass
-the fetch objects when initiating the FaunaDB client config. Cloudflare also
-doesn't support AbortController, which terminates requests as well as streams.
+Cloudflare Workers have neither XMLHttpRequest nor fetch in the global scope.
+Therefore, the `cross-fetch` package is unable to inject its own `fetch()` function, and throws an error.
+The `fetch()` function is injected via a closure, so the workaround would be to pass
+the fetch objects when initiating the FaunaDB client config. Cloudflare Workers also
+doesn't support the use of an AbortController, which terminates requests as well as streams.
 Here is a workaround:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -242,14 +242,16 @@ const client = new faunadb.Client({
 })
 ```
 
-## Knowing issues
+## Known issues
 
-### Using at Cloudflare workers
+### Using with Cloudflare Workers
 
-Cloudflare workers doesn't have XMLHttpRequest neither fetch in global scope,
-therefore cross-fetch package unable to inject fetch and throw an error.
-fetch function is injected via closure, so workaround would be to pass
-those fetch object to initiate FaunaDB client config. Cloudflare also doesn't support AbortController which terminate requests as well as streams. Here is workaround
+Cloudflare Workers has neither XMLHttpRequest nor fetch in global scope.
+Therefore, cross-fetch package is unable to inject fetch, and throws an error.
+fetch function is injected via closure, so the workaround would be to pass
+the fetch objects when initiating the FaunaDB client config. Cloudflare also
+doesn't support AbortController, which terminates requests as well as streams.
+Here is a workaround:
 
 ```javascript
 const c = new faunadb.Client({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1341,10 +1341,13 @@
       "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
       "dev": true
     },
-    "abortcontroller-polyfill": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.1.tgz",
-      "integrity": "sha512-yml9NiDEH4M4p0G4AcPkg8AAa4mF3nfYF28VQxaokpO67j9H7gWgmsVWJ/f1Rn+PzsnDYvzJzWIQzCqDKRvWlA=="
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "acorn": {
       "version": "7.1.1",
@@ -3472,6 +3475,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "events": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "types": "index.d.ts",
   "dependencies": {
-    "abortcontroller-polyfill": "^1.7.1",
+    "abort-controller": "^3.0.0",
     "base64-js": "^1.2.0",
     "browser-detect": "^0.2.28",
     "btoa-lite": "^1.0.0",

--- a/src/_http.js
+++ b/src/_http.js
@@ -2,10 +2,7 @@
 
 var pjson = require('../package.json')
 var util = require('./_util')
-var {
-  AbortController,
-  abortableFetch,
-} = require('abortcontroller-polyfill/dist/cjs-ponyfill')
+require('abort-controller/polyfill')
 const { formatUrl } = require('./_util')
 
 /**
@@ -173,10 +170,9 @@ function resolveFetch(fetchOverride, preferPolyfill) {
   }
 
   if (delegate !== null) {
-    var abortableDelegate = abortableFetch(delegate).fetch
     var fetch = function() {
       // NB. Rebinding to global is needed for Safari.
-      return abortableDelegate.apply(global, arguments)
+      return delegate.apply(global, arguments)
     }
     fetch.polyfill = true
     fetch.override = override

--- a/src/_util.js
+++ b/src/_util.js
@@ -43,6 +43,7 @@ function inherits(ctor, superCtor) {
  */
 function isNodeEnv() {
   return (
+    typeof window === 'undefined' &&
     typeof process !== 'undefined' &&
     process.versions != null &&
     process.versions.node != null

--- a/src/_util.js
+++ b/src/_util.js
@@ -42,7 +42,11 @@ function inherits(ctor, superCtor) {
  * @private
  */
 function isNodeEnv() {
-  return typeof window === 'undefined'
+  return (
+    typeof process !== 'undefined' &&
+    process.versions != null &&
+    process.versions.node != null
+  )
 }
 
 /**

--- a/src/stream.js
+++ b/src/stream.js
@@ -12,10 +12,7 @@
 // visibility control. However, DO NOT change any internal state from outside of
 // its context as it'd most certainly lead to errors.
 
-var {
-  AbortController,
-  abortableFetch,
-} = require('abortcontroller-polyfill/dist/cjs-ponyfill')
+require('abort-controller/polyfill')
 var RequestResult = require('./RequestResult')
 var errors = require('./errors')
 var http = require('./_http')


### PR DESCRIPTION
Abort controller polyfill has been changed because of cloudflare issue
```
(node:16784) UnhandledPromiseRejectionWarning: TypeError: AbortController is not a constructor
    at r.execute (/Users/szinkevych/projects/faunadb/fauna-express/functions/index.js:164:2194)
    at d._execute (/Users/szinkevych/projects/faunadb/fauna-express/functions/index.js:325:32329)
    at d.query (/Users/szinkevych/projects/faunadb/fauna-express/functions/index.js:325:31673)
```
However, that polyfill simply rejects a promise but not terminating a request. So we have to return the previous AbortController. Cloudflare team doesn't intend to implement AbortController https://community.cloudflare.com/t/timeout-with-fetch/25249/4. The possible workaround has been added to Readme.md

One more issue appears at Cloudflare, as wrangler build using NodeJS env but Cloudflare worker running as service worker (at browser) `isNodeEnv` doesn't behave correctly, therefore it leads to issue as we remove `http`,`https` polyfills from browser bundle to minify size.