### PR TITLE
DRV-371: alter Subscription#start error message for the case when the…

### DIFF
--- a/src/stream.js
+++ b/src/stream.js
@@ -113,7 +113,10 @@ StreamClient.prototype.subscribe = function() {
   if (self._state === 'idle') {
     self._state = 'open'
   } else {
-    throw new Error('The stream has already been started.')
+    throw new Error(
+      'Subscription#start should not be called several times, ' +
+        'consider instantiating a new stream instead.'
+    )
   }
 
   var body = JSON.stringify(self._query)


### PR DESCRIPTION
Alter `Subscription#start` error message to be more understandable for developers.
See PierBover comments for more details: https://github.com/fauna/faunadb-js/issues/374

### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/DRV-371)

### How to test
* try to call the `Subscription#start` method when the stream has already been started
* assert updated error message