### PR TITLE
Add missing type definitions

### DIFF
--- a/src/RequestResult.js
+++ b/src/RequestResult.js
@@ -94,19 +94,3 @@ Object.defineProperty(RequestResult.prototype, 'timeTaken', {
 })
 
 module.exports = RequestResult
-
-// /**
-//  * A structure containing the response errors for a given FaunaDB request.
-//  * Provided to an observer function optionally defined in the {@link Client} constructor.
-//  *
-//  * @param {'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'} method
-//  *   The HTTP method used in the request.
-//  * @param {Array.<{code: string, description: string}>} errors
-//  * @constructor
-//  */
-// function FaunaHttpErrorResponseContent(errors) {
-//   /** @type {Array.<{code: string, description: string}>} */
-//   this.errors = errors
-// }
-
-// module.exports.FaunaHttpErrorResponseContent = FaunaHttpErrorResponseContent

--- a/src/RequestResult.js
+++ b/src/RequestResult.js
@@ -16,7 +16,7 @@
  *   The request data.
  * @param {string} responseRaw
  *   The unparsed response data, as a string.
- * @param {object} responseContent
+ * @param {object | FaunaHttpErrorResponseContent} responseContent
  *   The response data parsed as JSON.
  * @param {number} statusCode
  *   The HTTP response status code.
@@ -65,8 +65,8 @@ function RequestResult(
 
   /**
    * Parsed value returned by the server.
-   * Includes "resource" wrapper dict, or may be an "errors" dict instead.
-   * @type {object}
+   * Includes "resource" wrapper dict, or may be an FaunaHttpErrorResponseContent instead
+   * @type {object | FaunaHttpErrorResponseContent}
    */
   this.responseContent = responseContent
 
@@ -94,3 +94,19 @@ Object.defineProperty(RequestResult.prototype, 'timeTaken', {
 })
 
 module.exports = RequestResult
+
+// /**
+//  * A structure containing the response errors for a given FaunaDB request.
+//  * Provided to an observer function optionally defined in the {@link Client} constructor.
+//  *
+//  * @param {'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'} method
+//  *   The HTTP method used in the request.
+//  * @param {Array.<{code: string, description: string}>} errors
+//  * @constructor
+//  */
+// function FaunaHttpErrorResponseContent(errors) {
+//   /** @type {Array.<{code: string, description: string}>} */
+//   this.errors = errors
+// }
+
+// module.exports.FaunaHttpErrorResponseContent = FaunaHttpErrorResponseContent

--- a/src/stream.js
+++ b/src/stream.js
@@ -149,9 +149,7 @@ StreamClient.prototype.subscribe = function() {
         body,
         self._query,
         parsed.text,
-        parsed.data && parsed.data.errors
-          ? new FaunaHttpErrorResponseContent(responseObject.errors)
-          : responseObject,
+        parsed.data,
         response.status,
         headers,
         startTime,

--- a/src/stream.js
+++ b/src/stream.js
@@ -149,7 +149,9 @@ StreamClient.prototype.subscribe = function() {
         body,
         self._query,
         parsed.text,
-        parsed.data,
+        parsed.data && parsed.data.errors
+          ? new FaunaHttpErrorResponseContent(responseObject.errors)
+          : responseObject,
         response.status,
         headers,
         startTime,

--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -28,7 +28,7 @@ export interface QueryOptions {
 
 export default class Client {
   constructor(opts?: ClientConfig)
-  query<T extends object = object>(expr: ExprArg, options?: QueryOptions): Promise<T>
+  query<T = object>(expr: ExprArg, options?: QueryOptions): Promise<T>
   paginate(expr: Expr, params?: object, options?: QueryOptions): PageHelper
   ping(scope?: string, timeout?: number): Promise<string>
   stream(expr: Expr, options?: { fields?: StreamEventFields[] }): Subscription

--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -1,6 +1,8 @@
+import { fetch } from 'cross-fetch'
+import { errors } from './errors'
 import Expr from './Expr'
-import { ExprArg } from './query'
 import PageHelper from './PageHelper'
+import { ExprArg } from './query'
 import RequestResult from './RequestResult'
 import { Subscription } from './Stream'
 
@@ -13,7 +15,7 @@ export interface ClientConfig {
   port?: number
   timeout?: number
   queryTimeout?: number
-  observer?: (res: RequestResult, client: Client) => void
+  observer?: <T extends object = object>(res: RequestResult<T | errors.FaunaHTTPError>, client: Client) => void
   keepAlive?: boolean
   headers?: { [key: string]: string | number }
   fetch?: typeof fetch
@@ -26,7 +28,7 @@ export interface QueryOptions {
 
 export default class Client {
   constructor(opts?: ClientConfig)
-  query<T = object>(expr: ExprArg, options?: QueryOptions): Promise<T>
+  query<T extends object = object>(expr: ExprArg, options?: QueryOptions): Promise<T>
   paginate(expr: Expr, params?: object, options?: QueryOptions): PageHelper
   ping(scope?: string, timeout?: number): Promise<string>
   stream(expr: Expr, options?: { fields?: StreamEventFields[] }): Subscription

--- a/src/types/RequestResult.d.ts
+++ b/src/types/RequestResult.d.ts
@@ -1,4 +1,4 @@
-export default class RequestResult {
+export default class RequestResult<T extends object = object> {
   constructor(
     method: string,
     path: string,
@@ -6,7 +6,7 @@ export default class RequestResult {
     requestRaw: string,
     requestContent: object,
     responseRaw: string,
-    responseContent: object,
+    responseContent: T,
     statusCode: number,
     responseHeaders: object,
     startTime: Date,
@@ -19,7 +19,7 @@ export default class RequestResult {
   readonly requestRaw: string
   readonly requestContent: object
   readonly responseRaw: string
-  readonly responseContent: object
+  readonly responseContent: T
   readonly statusCode: number
   readonly responseHeaders: object
   readonly startTime: Date

--- a/src/types/errors.d.ts
+++ b/src/types/errors.d.ts
@@ -1,5 +1,11 @@
 import RequestResult from './RequestResult'
 
+export type FaunaHttpErrorResponseContent = {
+  errors: {
+    code: string,
+    description: string
+  }[]
+}
 export module errors {
   export class FaunaError extends Error {
     constructor(message: string)
@@ -10,13 +16,12 @@ export module errors {
   }
 
   export class InvalidValue extends FaunaError {}
-
   export class FaunaHTTPError extends FaunaError {
-    static raiseForStatusCode(requestResult: RequestResult): void
+    static raiseForStatusCode(requestResult: RequestResult<FaunaHttpErrorResponseContent>): void
 
-    constructor(name: string, requestResult: RequestResult)
+    constructor(name: string, requestResult: RequestResult<FaunaHttpErrorResponseContent>)
 
-    requestResult: RequestResult
+    requestResult: RequestResult<FaunaHttpErrorResponseContent>
     errors(): object
   }
 


### PR DESCRIPTION
### Notes
[DRV-435](https://faunadb.atlassian.net/browse/DRV-435)

Linked issues
https://github.com/fauna/faunadb-js/issues/384
https://github.com/fauna/faunadb-js/issues/341

### How to test
tsconfig.json should have "lib": ['es2019']. in that case ts will not inject type for `fetch` (will only if lib has `DOM`)
No typescript error should be thrown
```javascript

import { Client, errors, FaunaHttpErrorResponseContent, query, values } from './index';

const client = new Client({
    secret: '',
    observer: (res => {
        if((res.responseContent as FaunaHttpErrorResponseContent).errors) {
            console.error('observer receive error')
            console.error(res.responseContent)
        }
    })
})


client.query<values.FaunaTime>(query.Now())
.then(now => {
    console.info('now ', now.date)
})
.catch((err: errors.FaunaHTTPError) => {
    console.error('query catch error')
    console.error(err.requestResult.responseContent.errors)
})

```