### PR TITLE
DRV-367: add api-version for Query

### DIFF
--- a/src/values.js
+++ b/src/values.js
@@ -361,7 +361,7 @@ util.inherits(Query, Value)
 
 wrapToString(Query, function() {
   const metadata = {
-    'api-version': +this.value.api_version,
+    api_version: +this.value.api_version,
   }
   return (
     'Query(' + Expr.toString(this.value) + ', ' + JSON.stringify(metadata) + ')'

--- a/src/values.js
+++ b/src/values.js
@@ -363,9 +363,23 @@ wrapToString(Query, function() {
   const metadata = {
     api_version: +this.value.api_version,
   }
-  return (
-    'Query(' + Expr.toString(this.value) + ', ' + JSON.stringify(metadata) + ')'
-  )
+
+  const notEmptyMetadata = Object.keys(metadata).some(key => metadata[key])
+
+  let stringified
+  if (notEmptyMetadata) {
+    stringified = [
+      'Query(',
+      Expr.toString(this.value),
+      ', ',
+      JSON.stringify(metadata),
+      ')',
+    ]
+  } else {
+    stringified = ['Query(', Expr.toString(this.value), ')']
+  }
+
+  return stringified.join('')
 })
 
 /** @ignore */

--- a/src/values.js
+++ b/src/values.js
@@ -360,7 +360,12 @@ function Query(value) {
 util.inherits(Query, Value)
 
 wrapToString(Query, function() {
-  return 'Query(' + Expr.toString(this.value) + ')'
+  const metadata = {
+    'api-version': +this.value.api_version,
+  }
+  return (
+    'Query(' + Expr.toString(this.value) + ', ' + JSON.stringify(metadata) + ')'
+  )
 })
 
 /** @ignore */

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -590,17 +590,17 @@ describe('Values', () => {
     // versioned queries/lambdas
     assertPrint(
       new Query({ api_version: '2.12', lambda: 'X', expr: { var: 'X' } }),
-      'Query(Lambda("X", Var("X")))'
+      'Query(Lambda("X", Var("X")), {"api_version":2.12})'
     )
 
     assertPrint(
       new Query({ api_version: '3', lambda: 'X', expr: { var: 'X' } }),
-      'Query(Lambda("X", Var("X")))'
+      'Query(Lambda("X", Var("X")), {"api_version":3})'
     )
 
     assertPrint(
       new Query({ lambda: 'X', expr: { var: 'X' }, api_version: '3' }),
-      'Query(Lambda("X", Var("X")))'
+      'Query(Lambda("X", Var("X")), {"api_version":3})'
     )
   })
 })


### PR DESCRIPTION
### Notes
[DRV-367 API version should always be reported when the current version is not 3 ](https://faunadb.atlassian.net/browse/DRV-367)

### How to test
```
  client.query(
    q.Query(q.Lambda('x', q.Var('x')))
  )
  .then((ret) => console.log(ret))
  .catch((err) => console.error('Error: %s', err))
```