### PR TITLE
runtime for nodejs v8 stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,15 @@ commands:
           command: yarn test
 
 jobs:
+  core-stable-8:
+    executor:
+      name: core
+      node_version: 8
+      version: stable
+    steps:
+      - build_and_test:
+          node_version: 8
+
   core-stable-10:
     executor:
       name: core
@@ -94,6 +103,8 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - core-stable-8:
+          context: faunadb-drivers
       - core-stable-10:
           context: faunadb-drivers
       - core-nightly-10:


### PR DESCRIPTION
 --expose-http2 flag enables experimental HTTP2 support. This flag can be used in nightly build (Node v8.4.0) since Aug 5, 2017 

Starting from NodeJS v8.8.1 you don’t need it flag.

so the PR added test env with nodejs v8