### PR TITLE
DRV-511 expr to FQL logic seems flawed.

### DIFF
--- a/src/Expr.js
+++ b/src/Expr.js
@@ -221,6 +221,24 @@ var exprToString = function(expr, caller) {
 
   if ('object' in expr) return printObject(expr['object'])
 
+  if ('merge' in expr) {
+    if (expr.lambda) {
+      return (
+        'Merge(' +
+        exprToString(expr.merge) +
+        ', ' +
+        exprToString(expr.with) +
+        ', ' +
+        exprToString(expr.lambda) +
+        ')'
+      )
+    }
+
+    return (
+      'Merge(' + exprToString(expr.merge) + ', ' + exprToString(expr.with) + ')'
+    )
+  }
+
   if ('lambda' in expr) {
     return (
       'Lambda(' +

--- a/src/query.js
+++ b/src/query.js
@@ -2987,7 +2987,7 @@ arity.between = function(min, max, args, callerFunc) {
 function params(mainParams, optionalParams) {
   for (var key in optionalParams) {
     var val = optionalParams[key]
-    if (val !== null) {
+    if (val !== null && val !== undefined) {
       mainParams[key] = val
     }
   }

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -620,6 +620,36 @@ describe('Values', () => {
     )
   })
 
+  test('pretty print Join', () => {
+    assertPrint(
+      new Query(
+        q.Join(
+          q.Match(
+            q.Index('spellbooks_by_owner'),
+            q.Ref(q.Collection('characters'), '181388642114077184')
+          ),
+          q.Index('spells_by_spellbook')
+        )
+      ),
+      'Query(Join(Match(Index("spellbooks_by_owner"), Ref(Collection("characters"), "181388642114077184")), Index("spells_by_spellbook")))'
+    )
+    assertPrint(
+      new Query(
+        q.Join(
+          q.Match(
+            q.Index('spellbooks_by_owner'),
+            q.Ref(q.Collection('characters'), '181388642114077184')
+          ),
+          q.Lambda(
+            'spellbook',
+            q.Match(q.Index('spells_by_spellbook'), q.Var('spellbook'))
+          )
+        )
+      ),
+      'Query(Join(Match(Index("spellbooks_by_owner"), Ref(Collection("characters"), "181388642114077184")), Lambda("spellbook", Match(Index("spells_by_spellbook"), Var("spellbook")))))'
+    )
+  })
+
   test('pretty print Expr with primitive types', () => {
     assertPrint(
       new Query(q.Lambda('_', { x: true, y: false, z: 'str', w: 10 })),

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -188,8 +188,8 @@ describe('Values', () => {
   })
 
   var assertPrint = function(value, expected) {
-    expect(expected).toEqual(util.inspect(value, { depth: null }))
-    expect(expected).toEqual(value.toString())
+    expect(util.inspect(value, { depth: null })).toEqual(expected)
+    expect(value.toString()).toEqual(expected)
   }
 
   test('allow collections with schema names', () => {
@@ -604,6 +604,19 @@ describe('Values', () => {
         })
       ),
       'Query(Merge(Select("data", Var("doc")), {id: Select(["ref", "id"], Var("doc"))}))'
+    )
+
+    assertPrint(
+      new Query(
+        q.Merge(
+          q.Select('data', q.Var('doc')),
+          {
+            id: q.Select(['ref', 'id'], q.Var('doc')),
+          },
+          q.Lambda(['key', 'a', 'b'], q.Var('a'))
+        )
+      ),
+      'Query(Merge(Select("data", Var("doc")), {id: Select(["ref", "id"], Var("doc"))}, Lambda(["key", "a", "b"], Var("a"))))'
     )
   })
 

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -596,6 +596,17 @@ describe('Values', () => {
     assertPrint(new Query(q.NewId()), 'Query(NewId())')
   })
 
+  test('pretty print Merge', () => {
+    assertPrint(
+      new Query(
+        q.Merge(q.Select('data', q.Var('doc')), {
+          id: q.Select(['ref', 'id'], q.Var('doc')),
+        })
+      ),
+      'Query(Merge(Select("data", Var("doc")), {id: Select(["ref", "id"], Var("doc"))}))'
+    )
+  })
+
   test('pretty print Expr with primitive types', () => {
     assertPrint(
       new Query(q.Lambda('_', { x: true, y: false, z: 'str', w: 10 })),


### PR DESCRIPTION
### Notes
[DRV-511 expr to FQL logic seems flawed.](https://faunadb.atlassian.net/browse/DRV-511)
Fix incorrect optional params checks. 
Fix toString for `Merge`

### How to test
```
console.info(new Query(
        q.Merge(q.Select('data', q.Var('doc')), {
          id: q.Select(['ref', 'id'], q.Var('doc')),
        })
      ))
```