### PR TITLE
Update fetchAdapter.js to use globalThis instead of global. 

### DIFF
--- a/src/_http/fetchAdapter.js
+++ b/src/_http/fetchAdapter.js
@@ -218,9 +218,9 @@ function resolveFetch(fetchOverride) {
     return fetchOverride
   }
 
-  if (typeof global.fetch === 'function') {
+  if (typeof globalThis.fetch === 'function') {
     // NB. Rebinding to global is needed for Safari
-    return global.fetch.bind(global)
+    return globalThis.fetch.bind(globalThis)
   }
 
   return require('cross-fetch')


### PR DESCRIPTION
### Notes
Sorry.  no Jira ticket.
### How to test
I had a situation where I needed faunadb to run in an SSR environment on top of Vite.  global was not found so I changed it to globalThis which handled the clientside compile for me.
### Screenshots