### PR TITLE
fix(htt2Adapter): set http2 session idle time

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "browserify": "browserify index.js --standalone faunadb -o dist/faunadb.js",
     "browserify-min": "browserify index.js --standalone faunadb | terser -c -m --keep-fnames --keep-classnames -o dist/faunadb-min.js",
     "prettify": "prettier --write \"{src,test}/**/*.{js,ts}\"",
-    "test": "jest --env=node --verbose=false ./test",
+    "test": "jest --env=node --verbose=false --forceExit ./test",
     "semantic-release": "semantic-release",
     "wp": "webpack"
   },

--- a/src/Client.js
+++ b/src/Client.js
@@ -155,6 +155,8 @@ var values = require('./values')
  *   a fetch compatible [API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for making a request
  * @param {?number} options.queryTimeout
  *   Sets the maximum amount of time (in milliseconds) for query execution on the server,
+ * @param {?number} options.http2SessionIdleTime
+ *   Sets the maximum amount of time (in milliseconds) for http2 session to release connection. By default 1 minute
  */
 function Client(options) {
   options = util.applyDefaults(options, {
@@ -168,6 +170,7 @@ function Client(options) {
     headers: {},
     fetch: undefined,
     queryTimeout: null,
+    http2SessionIdleTime: 1000 * 60,
   })
 
   this._observer = options.observer

--- a/src/Client.js
+++ b/src/Client.js
@@ -156,7 +156,7 @@ var values = require('./values')
  * @param {?number} options.queryTimeout
  *   Sets the maximum amount of time (in milliseconds) for query execution on the server,
  * @param {?number} options.http2SessionIdleTime
- *   Sets the maximum amount of time (in milliseconds) for http2 session to release connection. By default 1 minute
+ *   Sets the maximum amount of time (in milliseconds) for http2 session to release connection. By default 500ms
  */
 function Client(options) {
   options = util.applyDefaults(options, {

--- a/src/Client.js
+++ b/src/Client.js
@@ -170,7 +170,7 @@ function Client(options) {
     headers: {},
     fetch: undefined,
     queryTimeout: null,
-    http2SessionIdleTime: 1000 * 60,
+    http2SessionIdleTime: 500,
   })
 
   this._observer = options.observer

--- a/src/_http/http2Adapter.js
+++ b/src/_http/http2Adapter.js
@@ -54,18 +54,11 @@ Http2Adapter.prototype._resolveSessionFor = function(origin, isStreaming) {
     }
 
     // Initializing http2 session.
-    this._sessionMap[sessionKey] = http2.connect(origin)
-
-    this._sessionMap[sessionKey].once('error', cleanup).once('goaway', cleanup)
-
-    if (this.http2SessionIdleTime) {
-      // Destroys http2 session after specified time of inactivity
-      // and releases event loop.
-      this._sessionMap[sessionKey].setTimeout(
-        this.http2SessionIdleTime,
-        cleanup
-      )
-    }
+    this._sessionMap[sessionKey] = http2
+      .connect(origin)
+      .once('error', cleanup)
+      .once('goaway', cleanup)
+      .setTimeout(this.http2SessionIdleTime, cleanup)
   }
 
   return this._sessionMap[sessionKey]

--- a/src/_http/http2Adapter.js
+++ b/src/_http/http2Adapter.js
@@ -58,6 +58,8 @@ Http2Adapter.prototype._resolveSessionFor = function(origin, isStreaming) {
       .connect(origin)
       .once('error', cleanup)
       .once('goaway', cleanup)
+      // Destroys http2 session after specified time of inactivity
+      // and releases event loop.
       .setTimeout(this.http2SessionIdleTime, cleanup)
   }
 

--- a/src/_http/http2Adapter.js
+++ b/src/_http/http2Adapter.js
@@ -3,8 +3,6 @@ var http2 = require('http2')
 var errors = require('./errors')
 var util = require('../_util')
 
-// Destroy session after 1 minute of inactivity.
-var DESTROY_HTTP2_SESSION_TIME = 1000 * 60
 var STREAM_PREFIX = 'stream::'
 
 /**
@@ -13,7 +11,7 @@ var STREAM_PREFIX = 'stream::'
  * @constructor
  * @private
  */
-function Http2Adapter() {
+function Http2Adapter(options) {
   /**
    * Identifies a type of adapter.
    *
@@ -27,6 +25,13 @@ function Http2Adapter() {
    * @private
    */
   this._sessionMap = {}
+
+  /**
+   Sets the maximum amount of time (in milliseconds) for session to release connection
+   *
+   * @type {number}
+   */
+  this.http2SessionIdleTime = options.http2SessionIdleTime
 }
 
 /**
@@ -49,13 +54,18 @@ Http2Adapter.prototype._resolveSessionFor = function(origin, isStreaming) {
     }
 
     // Initializing http2 session.
-    this._sessionMap[sessionKey] = http2
-      .connect(origin)
-      .once('error', cleanup)
-      .once('goaway', cleanup)
+    this._sessionMap[sessionKey] = http2.connect(origin)
+
+    this._sessionMap[sessionKey].once('error', cleanup).once('goaway', cleanup)
+
+    if (this.http2SessionIdleTime) {
       // Destroys http2 session after specified time of inactivity
       // and releases event loop.
-      .setTimeout(DESTROY_HTTP2_SESSION_TIME, cleanup)
+      this._sessionMap[sessionKey].setTimeout(
+        this.http2SessionIdleTime,
+        cleanup
+      )
+    }
   }
 
   return this._sessionMap[sessionKey]

--- a/src/_http/index.js
+++ b/src/_http/index.js
@@ -22,7 +22,9 @@ function HttpClient(options) {
   var useHttp2Adapter = !options.fetch && util.isNodeEnv() && isHttp2Supported()
 
   this._adapter = useHttp2Adapter
-    ? new (require('./http2Adapter'))()
+    ? new (require('./http2Adapter'))({
+        http2SessionIdleTime: options.http2SessionIdleTime,
+      })
     : new (require('./fetchAdapter'))({
         isHttps: isHttps,
         fetch: options.fetch,


### PR DESCRIPTION
### Notes
[DRV-523](https://faunadb.atlassian.net/browse/DRV-523)

This is related to how http2 sessions work, a http2 session should be reused across multiple calls thus should have some lifetime specified. By default, it’s set to 60 secs which is reasonable for most web services (when having continuous incoming traffic). But unfortunately, I haven’t considered such cases like using fauna-shell - it definitely doesn’t make sense to keep this session for a long time in such scenarios.
The tricky question is to decide the reasonable/versatile lifetime for http2 sessions as the driver has a lot of use-cases in different environments. We could accept this http2 session lifetime via params when constructing the Client e.g. http2Lifetime but would it confuse the customer to configure it by themself?

Solution is taken from [google client](https://github.com/googleapis/nodejs-googleapis-common/blob/master/src/http2.ts#L208)
