### PR TITLE
FE-671 - expose API version as a Client's static property

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var packageJson = require('../package.json')
 var PageHelper = require('./PageHelper')
 var RequestResult = require('./RequestResult')
 var errors = require('./errors')
@@ -175,6 +176,13 @@ function Client(options) {
   this._http = new http.HttpClient(options)
   this.stream = stream.StreamAPI(this)
 }
+
+/**
+ * Current API version.
+ *
+ * @type {string}
+ */
+Client.apiVersion = packageJson.apiVersion
 
 /**
  * Executes a query via the FaunaDB Query API.


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-671)
Currently, it's not possible to get the API version of the JS driver. It's required for the FE ticket in order to show a warning in the case when versions differ. See Jira ticket for more details.

### How to test
* try access `Client.apiVersion` static property
* assert it equals to package.json one
