### PR TITLE
FE-1142 - fix Stream API type definition (TypeScript)

### DIFF
--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -15,13 +15,29 @@ export interface ClientConfig {
   port?: number
   timeout?: number
   queryTimeout?: number
-  observer?: <T extends object = object>(res: RequestResult<T | errors.FaunaHTTPError>, client: Client) => void
+  observer?: <T extends object = object>(
+    res: RequestResult<T | errors.FaunaHTTPError>,
+    client: Client
+  ) => void
   keepAlive?: boolean
   headers?: { [key: string]: string | number }
   fetch?: typeof fetch
 }
 
-export interface QueryOptions extends Partial<Pick<ClientConfig, 'secret' | 'queryTimeout' | 'fetch' | 'observer'>> {
+export interface QueryOptions
+  extends Partial<
+    Pick<ClientConfig, 'secret' | 'queryTimeout' | 'fetch' | 'observer'>
+  > {}
+
+type StreamFn = (
+  expr: Expr,
+  options?: {
+    fields?: StreamEventFields[]
+  }
+) => Subscription
+
+interface StreamApi extends StreamFn {
+  document: StreamFn
 }
 
 export default class Client {
@@ -29,5 +45,5 @@ export default class Client {
   query<T = object>(expr: ExprArg, options?: QueryOptions): Promise<T>
   paginate(expr: Expr, params?: object, options?: QueryOptions): PageHelper
   ping(scope?: string, timeout?: number): Promise<string>
-  stream(expr: Expr, options?: { fields?: StreamEventFields[] }): Subscription
+  stream: StreamApi
 }


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-1142)
Fix type definition for Stream API to expose `.document` function from `Client#stream` one.

### How to test
* try to access `Client#stream.document` property
* assert it has the same type signature as `Client#stream` function