### PR TITLE
fix: cloudflare doesn't have navigator object

### DIFF
--- a/src/_http/index.js
+++ b/src/_http/index.js
@@ -123,14 +123,24 @@ function getDefaultHeaders() {
     driver: ['javascript', packageJson.version].join('-'),
   }
 
+  let isServiceWorker
+
+  try {
+    isServiceWorker = global instanceof ServiceWorkerGlobalScope
+  } catch (error) {
+    isServiceWorker = false
+  }
+
   if (util.isNodeEnv()) {
     driverEnv.runtime = ['nodejs', process.version].join('-')
     driverEnv.env = util.getNodeRuntimeEnv()
     var os = require('os')
     driverEnv.os = [os.platform(), os.release()].join('-')
+  } else if (isServiceWorker) {
+    driverEnv.runtime = 'Service Worker'
   } else {
     driverEnv.runtime = util.getBrowserDetails()
-    driverEnv.env = 'unknown'
+    driverEnv.env = 'browser'
     driverEnv.os = getBrowserOsDetails()
   }
 

--- a/src/_http/index.js
+++ b/src/_http/index.js
@@ -131,18 +131,20 @@ function getDefaultHeaders() {
     isServiceWorker = false
   }
 
-  if (util.isNodeEnv()) {
-    driverEnv.runtime = ['nodejs', process.version].join('-')
-    driverEnv.env = util.getNodeRuntimeEnv()
-    var os = require('os')
-    driverEnv.os = [os.platform(), os.release()].join('-')
-  } else if (isServiceWorker) {
-    driverEnv.runtime = 'Service Worker'
-  } else {
-    driverEnv.runtime = util.getBrowserDetails()
-    driverEnv.env = 'browser'
-    driverEnv.os = getBrowserOsDetails()
-  }
+  try {
+    if (util.isNodeEnv()) {
+      driverEnv.runtime = ['nodejs', process.version].join('-')
+      driverEnv.env = util.getNodeRuntimeEnv()
+      var os = require('os')
+      driverEnv.os = [os.platform(), os.release()].join('-')
+    } else if (isServiceWorker) {
+      driverEnv.runtime = 'Service Worker'
+    } else {
+      driverEnv.runtime = util.getBrowserDetails()
+      driverEnv.env = 'browser'
+      driverEnv.os = getBrowserOsDetails()
+    }
+  } catch (_) {}
 
   var headers = {
     'X-FaunaDB-API-Version': packageJson.apiVersion,

--- a/src/_http/index.js
+++ b/src/_http/index.js
@@ -123,7 +123,7 @@ function getDefaultHeaders() {
     driver: ['javascript', packageJson.version].join('-'),
   }
 
-  let isServiceWorker
+  var isServiceWorker
 
   try {
     isServiceWorker = global instanceof ServiceWorkerGlobalScope

--- a/src/_util.js
+++ b/src/_util.js
@@ -249,16 +249,6 @@ function getNodeRuntimeEnv() {
         process.env.ORYX_ENV_TYPE === 'AppService',
     },
     {
-      name: 'Worker',
-      check: () => {
-        try {
-          return global instanceof ServiceWorkerGlobalScope
-        } catch (error) {
-          return false
-        }
-      },
-    },
-    {
       name: 'Mongo Stitch',
       check: () => typeof global.StitchError === 'function',
     },


### PR DESCRIPTION
### Notes
[DRV-566 Cloudflare doesn't have navigator object](https://faunadb.atlassian.net/browse/DRV-566)
Issue: https://github.com/fauna/faunadb-js/issues/447

Running 4.1.2 produce an error at CloudFlare
```
ReferenceError: navigator is not defined
    at Object.getBrowserDetails (worker.js:1:2773)
    at worker.js:6:5260
    at new s (worker.js:6:5461)
    at new d (worker.js:6:17008)
    at new a (worker.js:6:33478)
    at s (worker.js:6:33984)
    at Proxy.e.r (worker.js:6:14246)
    at worker.js:6:34805
```