### PR TITLE
DRV-575 - implement Client#close method

### DIFF
--- a/src/_http/index.js
+++ b/src/_http/index.js
@@ -62,6 +62,17 @@ HttpClient.prototype.syncLastTxnTime = function(time) {
 }
 
 /**
+ * Cleanups the held resources.
+ *
+ * @returns {void}
+ */
+HttpClient.prototype.close = function() {
+  if (this._adapter.close) {
+    this._adapter.close()
+  }
+}
+
+/**
  * Executes an HTTP request.
  *
  * @param {?object} options Request parameters.

--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -22,6 +22,7 @@ export interface ClientConfig {
   keepAlive?: boolean
   headers?: { [key: string]: string | number }
   fetch?: typeof fetch
+  http2SessionIdleTime?: number
 }
 
 export interface QueryOptions
@@ -45,5 +46,6 @@ export default class Client {
   query<T = object>(expr: ExprArg, options?: QueryOptions): Promise<T>
   paginate(expr: Expr, params?: object, options?: QueryOptions): PageHelper
   ping(scope?: string, timeout?: number): Promise<string>
+  close(): void
   stream: StreamApi
 }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -143,6 +143,21 @@ describe('Client', () => {
     return expect(resultWithoutOptions).toEqual(resultWithOptions)
   })
 
+  test('cleanups http2 resources when .close is called', async () => {
+    const client = util.getClient()
+
+    const assertActiveSessions = length =>
+      expect(Object.keys(client._http._adapter._sessionMap).length).toBe(length)
+
+    await client.ping()
+
+    assertActiveSessions(1)
+
+    client.close()
+
+    assertActiveSessions(0)
+  })
+
   test('uses custom fetch', async function() {
     const fetch = jest.fn(() =>
       Promise.resolve({


### PR DESCRIPTION
Implemented `Client#close` method for cleaning up http2 resources and releasing the Event Loop when run on NodeJS environment.

### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/DRV-575)

### How to test
* create a client instance on NodeJS env
* fire some requests
* call `.close` method on that instance and ensure the Event Loop is released