### PR TITLE
feature!: remove coupling between StreamApi and Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ import Var from 'faunadb/query/Var'
 
 faunadb-js from version 5.X.X support EcmaScript modules system which brings availability for bundle tools like webpack, rollup execute three-shake package and remove unused code, therefore bundle size would be smaller
 
+##### Faunadb imports (TBD if this have to be public API)
+
+```diff
+const faunadb = require('faunadb')
+- const { Ref, FaunaDate, Bytes, ... } = faunadb.values
++ const { Ref, FaunaDate, Bytes, ... } = faunadb
+
+- const { InvalidArity, FaunaHTTPError, BadRequest, ... } = faunadb.errors
++ const { InvalidArity, FaunaHTTPError, BadRequest, ... } = faunadb
+
+- const { logger, showRequestResult } = faunadb.clientLogger
++ // removed as faunadb doesn't have described type for clientLogger
+
+```
+
 ##### Import query functions
 
 All query functions has been removed from main package and hosted under sub-module `faunadb/query`.
@@ -211,11 +226,11 @@ client.query(
 ##### Streaming API
 
 ```diff
-const { Client } = require('faunadb')
+const faunadb = require('faunadb')
 const q = require('faunadb/query')
 + const Stream = require('faunadb/stream')
-const client = new Client({secret: 'YOUR_FAUNA_SECRET'})
-+ const streamApi = new Stream.Api({ client })
+const client = new faunadb.Client({secret: 'YOUR_FAUNA_SECRET'})
++ const streamApi = new StreamApi({ client })
 const docRef = q.Ref(q.Collection('Scores'), '1')
 
 let stream

--- a/README.md
+++ b/README.md
@@ -213,7 +213,33 @@ client.query(
 
 ##### Streaming API
 
-Doc would be ready as soon as stream api extracted from main package
+```diff
+- const { Client } = require('faunadb')
++ const { Client, StreamAPI } = require('faunadb')
+const client = new Client({secret: 'YOUR_FAUNA_SECRET'})
++ const streamApi = new StreamAPI({ client })
+const docRef = q.Ref(q.Collection('Scores'), '1')
+
+let stream
+const startStream = () => {
+-  stream = client.stream.document(docRef)
++  stream = streamApi.document(docRef)
+  .on('snapshot', snapshot => {
+    report(snapshot)
+  })
+  .on('version', version => {
+    report(version)
+  })
+  .on('error', error => {
+    console.log('Error:', error)
+    stream.close()
+    setTimeout(startStream, 1000)
+  })
+  .start()
+}
+
+startStream()
+```
 
 #### Pagination Helpers
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To get up and running quickly, below is a full example for connecting from the b
     scheme: 'https',
   })
   client.query(
-    faunadb.ToDate('2018-06-06')
+    faunadb.query.ToDate('2018-06-06')
   )
   .then(function (res) { console.log('Result:', res) })
   .catch(function (err) { console.log('Error:', err) })
@@ -173,9 +173,6 @@ EcmaScript
 ```javascript
 import Client from 'faunadb'
 
-// Import query from root
-import { Select } from 'faunadb'
-
 // Import all queries by one command
 import * as q from 'faunadb/query'
 
@@ -214,10 +211,11 @@ client.query(
 ##### Streaming API
 
 ```diff
-- const { Client } = require('faunadb')
-+ const { Client, StreamAPI } = require('faunadb')
+const { Client } = require('faunadb')
+const q = require('faunadb/query')
++ const Stream = require('faunadb/stream')
 const client = new Client({secret: 'YOUR_FAUNA_SECRET'})
-+ const streamApi = new StreamAPI({ client })
++ const streamApi = new Stream.Api({ client })
 const docRef = q.Ref(q.Collection('Scores'), '1')
 
 let stream

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ const faunadb = require('faunadb')
 + const { InvalidArity, FaunaHTTPError, BadRequest, ... } = faunadb
 
 - const { logger, showRequestResult } = faunadb.clientLogger
-+ // removed as faunadb doesn't have described type for clientLogger
++ const { logger, showRequestResult } = faunadb
 
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,9 +2,11 @@ export { default as Client } from './src/types/Client';
 export { default as Expr } from './src/types/Expr';
 export { default as PageHelper } from './src/types/PageHelper';
 export { default as RequestResult } from './src/types/RequestResult';
+export { default as Stream } from './src/types/RequestResult';
 export * as query from './src/types/query';
 
 export * from './src/types/Client';
+export * from './src/types/Stream';
 export * from './src/types/errors';
 export * from './src/types/Expr';
 export * from './src/types/values';

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,14 +2,6 @@ export { default as Client } from './src/types/Client';
 export { default as Expr } from './src/types/Expr';
 export { default as PageHelper } from './src/types/PageHelper';
 export { default as RequestResult } from './src/types/RequestResult';
-export { default as Stream } from './src/types/RequestResult';
-export * as query from './src/types/query';
 
-export * from './src/types/Client';
-export * from './src/types/Stream';
 export * from './src/types/errors';
-export * from './src/types/Expr';
 export * from './src/types/values';
-export * from './src/types/PageHelper';
-export * from './src/types/query';
-export * from './src/types/RequestResult';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10744,6 +10744,29 @@
         "minimist": "^1.2.5"
       }
     },
+    "modify-source-webpack-plugin": {
+      "version": "1.1.0-beta.3",
+      "resolved": "https://registry.npmjs.org/modify-source-webpack-plugin/-/modify-source-webpack-plugin-1.1.0-beta.3.tgz",
+      "integrity": "sha512-2TulyszJfAmw7QrTTSn1qRMUyDqJbMoMoFRFqKr2ponQmU9WDx8VLGtGXGX1MKUOYrosduya8vlcXl0BGijBVw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        }
+      }
+    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
       "require": "./cjs/index.js",
       "import": "./esm5/index.js"
     },
+    "./stream": {
+      "require": "./cjs/stream.js",
+      "import": "./esm5/stream.js"
+    },
     "./query": {
       "require": "./cjs/query/index.js",
       "import": "./esm5/query/index.js"
@@ -86,6 +90,7 @@
     "jest": "^26.6.3",
     "jsdoc": "^3.6.3",
     "lint-staged": ">=8",
+    "modify-source-webpack-plugin": "^1.1.0-beta.3",
     "npm-run-all": "^4.1.5",
     "prettier": "1.18.2",
     "semantic-release": "^17.1.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,24 @@
   "main": "./cjs/index.js",
   "module": "./esm5/index.js",
   "es2015": "./src/index.js",
+  "exports": {
+    ".": {
+      "require": "./cjs/index.js",
+      "import": "./esm5/index.js"
+    },
+    "./query": {
+      "require": "./cjs/query/index.js",
+      "import": "./esm5/query/index.js"
+    },
+    "./query/": {
+      "require": "./cjs/query/",
+      "import": "./esm5/query/"
+    },
+    "./query/*": {
+      "require": "./cjs/query/*.js",
+      "import": "./esm5/query/*.js"
+    }
+  },
   "scripts": {
     "doc": "jsdoc -c ./jsdoc.json",
     "prettify": "prettier --write \"{src,test}/**/*.{js,ts}\"",

--- a/src/Client.js
+++ b/src/Client.js
@@ -5,7 +5,6 @@ import { FaunaHTTPError } from './errors'
 import PageHelper from './PageHelper'
 import { wrap } from './query/common'
 import RequestResult from './RequestResult'
-import StreamAPI from './stream'
 import { Ref } from './values'
 import HttpClient from './_http'
 import { parseJSON } from './_json'
@@ -179,7 +178,6 @@ export default function Client(options) {
 
   this._observer = options.observer
   this._http = new HttpClient(options)
-  this.stream = StreamAPI(this)
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ export { default as Expr } from './Expr'
 export { default as PageHelper } from './PageHelper'
 export * from './query'
 export { default as RequestResult } from './RequestResult'
+export { default as StreamAPI } from './stream'
 
 import * as _clientLogger from './clientLogger'
 import * as _errors from './errors'

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export { default as Client } from './Client'
+export * from './clientLogger'
 export * from './errors'
 export { default as Expr } from './Expr'
 export { default as PageHelper } from './PageHelper'

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 export { default as Client, default } from './Client'
 export { default as Expr } from './Expr'
 export { default as PageHelper } from './PageHelper'
-export * from './query'
 export { default as RequestResult } from './RequestResult'
-export { default as StreamAPI } from './stream'
+
+/* @replace:umd_imports (webpack will import all queries and stream api) */
 
 import * as _clientLogger from './clientLogger'
 import * as _errors from './errors'

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,8 @@
-export { default as Client, default } from './Client'
+export { default as Client } from './Client'
+export * from './errors'
 export { default as Expr } from './Expr'
 export { default as PageHelper } from './PageHelper'
 export { default as RequestResult } from './RequestResult'
+export * from './values'
 
 /* @replace:umd_imports (webpack will import all queries and stream api) */
-
-import * as _clientLogger from './clientLogger'
-import * as _errors from './errors'
-import * as _values from './values'
-export const errors = _errors
-export const values = _values
-export const clientLogger = _clientLogger

--- a/src/stream.js
+++ b/src/stream.js
@@ -409,3 +409,5 @@ export function Api({ client }) {
 
   return api
 }
+
+export default { Api }

--- a/src/stream.js
+++ b/src/stream.js
@@ -354,7 +354,7 @@ Subscription.prototype.close = function() {
  * use stream's public interface.
  * @private
  */
-export default function StreamAPI(client) {
+export default function StreamAPI({ client }) {
   var api = function(expression, options) {
     var dispatcher = new EventDispatcher(DefaultEvents)
     var streamClient = new StreamClient(client, expression, options, function(

--- a/src/stream.js
+++ b/src/stream.js
@@ -354,7 +354,7 @@ Subscription.prototype.close = function() {
  * use stream's public interface.
  * @private
  */
-export function Api({ client }) {
+export function StreamApi({ client }) {
   var api = function(expression, options) {
     var dispatcher = new EventDispatcher(DefaultEvents)
     var streamClient = new StreamClient(client, expression, options, function(
@@ -409,5 +409,3 @@ export function Api({ client }) {
 
   return api
 }
-
-export default { Api }

--- a/src/stream.js
+++ b/src/stream.js
@@ -354,7 +354,7 @@ Subscription.prototype.close = function() {
  * use stream's public interface.
  * @private
  */
-export default function StreamAPI({ client }) {
+export function Api({ client }) {
   var api = function(expression, options) {
     var dispatcher = new EventDispatcher(DefaultEvents)
     var streamClient = new StreamClient(client, expression, options, function(

--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -6,8 +6,6 @@ import { ExprArg } from './query'
 import RequestResult from './RequestResult'
 import { Subscription } from './Stream'
 
-type StreamEventFields = ['action', 'document', 'diff', 'prev']
-
 export interface ClientConfig {
   secret: string
   domain?: string
@@ -29,21 +27,9 @@ export interface QueryOptions
     Pick<ClientConfig, 'secret' | 'queryTimeout' | 'fetch' | 'observer'>
   > {}
 
-type StreamFn = (
-  expr: Expr,
-  options?: {
-    fields?: StreamEventFields[]
-  }
-) => Subscription
-
-interface StreamApi extends StreamFn {
-  document: StreamFn
-}
-
 export default class Client {
   constructor(opts?: ClientConfig)
   query<T = object>(expr: ExprArg, options?: QueryOptions): Promise<T>
   paginate(expr: Expr, params?: object, options?: QueryOptions): PageHelper
   ping(scope?: string, timeout?: number): Promise<string>
-  stream: StreamApi
 }

--- a/src/types/Stream.d.ts
+++ b/src/types/Stream.d.ts
@@ -1,6 +1,17 @@
-import Client from './Client'
-import { ExprArg } from './query'
-import { values } from './values'
+import Expr from './Expr'
+
+type StreamEventFields = ['action', 'document', 'diff', 'prev']
+
+type StreamFn = (
+  expr: Expr,
+  options?: {
+    fields?: StreamEventFields[]
+  }
+) => Subscription
+
+export interface StreamApi extends StreamFn {
+  document: StreamFn
+}
 
 export interface Subscription {
   on: <T extends keyof SubscriptionEventHandlers>(

--- a/src/types/Stream.d.ts
+++ b/src/types/Stream.d.ts
@@ -13,6 +13,10 @@ export interface StreamApi extends StreamFn {
   document: StreamFn
 }
 
+export default interface Stream {
+  Api: StreamApi
+}
+
 export interface Subscription {
   on: <T extends keyof SubscriptionEventHandlers>(
     type: T,

--- a/src/types/Stream.d.ts
+++ b/src/types/Stream.d.ts
@@ -13,10 +13,6 @@ export interface StreamApi extends StreamFn {
   document: StreamFn
 }
 
-export default interface Stream {
-  Api: StreamApi
-}
-
 export interface Subscription {
   on: <T extends keyof SubscriptionEventHandlers>(
     type: T,

--- a/stream/package.json
+++ b/stream/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "faunadb/stream",
+  "version": "4.1.1",
+  "apiVersion": "4",
+  "description": "FaunaDB Javascript driver for Node.JS and Browsers",
+  "browser": {
+    "http2": false,
+    "http": false,
+    "https": false,
+    "os": false,
+    "util": false
+  },
+  "types": "../src/types/stream.d.ts",
+  "main": "../cjs/stream.js",
+  "module": "../esm5/stream.js",
+  "es2015": "../src/stream.js",
+  "sideEffects": false
+}

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -328,7 +328,7 @@ describe('StreamAPI', () => {
     test('report failure during snapshot', done => {
       // Non-existing ref should fail to run q.Get(..).
       let ref = q.Ref(coll.ref, 1234)
-      stream = client.stream
+      stream = streamApi
         .document(ref)
         .on('snapshot', snapshot => {})
         .on('error', error => {

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -2,7 +2,7 @@
 
 import { BadRequest } from '../src/errors'
 import * as q from '../src/query'
-import Stream from '../src/stream'
+import { StreamApi } from '../src/stream'
 import * as util from './util'
 
 let db, key, client, coll, doc, stream, window, fetch, streamApi
@@ -26,7 +26,7 @@ describe('StreamAPI', () => {
     client = util.getClient({
       secret: key.secret,
     })
-    streamApi = new Stream.Api({ client })
+    streamApi = new StreamApi({ client })
     coll = await client.query(
       q.CreateCollection({
         name: 'stream_docs',
@@ -127,7 +127,7 @@ describe('StreamAPI', () => {
         })
       )
       let key = await client.query(q.CreateKey({ role: role.ref }))
-      stream = new Stream.Api({
+      stream = new StreamApi({
         client: util.getClient({ secret: key.secret }),
       })
         .document(doc.ref)
@@ -172,14 +172,14 @@ describe('StreamAPI', () => {
           done()
         },
       })
-      stream = new Stream.Api({ client }).document(doc.ref).start()
+      stream = new StreamApi({ client }).document(doc.ref).start()
     })
 
     test('use client fetch override if available', done => {
       let client = util.getClient({
         fetch: () => Promise.reject(new Error('client fetch used')),
       })
-      stream = new Stream.Api({ client })
+      stream = new StreamApi({ client })
         .document(doc.ref)
         .on('error', error => {
           expect(error.message).toEqual('client fetch used')
@@ -196,7 +196,7 @@ describe('StreamAPI', () => {
       // HttpClient's adapter and pull new fetch API from global.
       const client = util.getClient()
 
-      stream = new Stream.Api({ client })
+      stream = new StreamApi({ client })
         .document(doc.ref)
         .on('error', error => {
           expect(error.message).toEqual('global fetch called')
@@ -214,7 +214,7 @@ describe('StreamAPI', () => {
         secret: key.secret,
       })
 
-      stream = new Stream.Api({ client })
+      stream = new StreamApi({ client })
         .document(doc.ref)
         .on('error', error => {
           expect(error.message).toEqual('streams not supported')
@@ -240,7 +240,7 @@ describe('StreamAPI', () => {
             },
           }),
       })
-      stream = new Stream.Api({ client })
+      stream = new StreamApi({ client })
         .document(doc.ref)
         .on('error', error => {
           expect(error.message).toEqual('streams not supported')
@@ -307,7 +307,7 @@ describe('StreamAPI', () => {
 
       let snapshot
 
-      stream = new Stream.Api({
+      stream = new StreamApi({
         client: util.getClient({ secret: key.secret, fetch: fetchWrapper }),
       })
         .document(doc.ref)

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -280,7 +280,7 @@ describe('StreamAPI', () => {
 
   describe('document', () => {
     test('can take snapshot before processing events', done => {
-      stream = client.stream
+      stream = streamApi
         .document(doc.ref)
         .on('snapshot', snapshot => {
           expect(snapshot.data).toEqual(doc.data)
@@ -307,9 +307,10 @@ describe('StreamAPI', () => {
 
       let snapshot
 
-      stream = util
-        .getClient({ secret: key.secret, fetch: fetchWrapper })
-        .stream.document(doc.ref)
+      stream = new Stream.Api({
+        client: util.getClient({ secret: key.secret, fetch: fetchWrapper }),
+      })
+        .document(doc.ref)
         .on('start', () => {
           buffering = true
         })

--- a/tools/postBuildPackage.js
+++ b/tools/postBuildPackage.js
@@ -25,20 +25,25 @@ writePkg({
 const rootAliases = [
   {
     alias: 'query',
+    main: 'query/index.js',
     aliasForFiles: true,
+  },
+  {
+    alias: 'stream',
+    main: 'stream.js',
   },
 ]
 
-rootAliases.forEach(({ alias, aliasForFiles, main = 'index' }) => {
+rootAliases.forEach(({ alias, aliasForFiles, main }) => {
   ensureDir(alias)
   writePkg({
     rootPath: alias,
     pkgManifest: {
       name: `faunadb/${alias}`,
       types: `../src/types/${alias}.d.ts`,
-      main: `../cjs/${alias}/${main}.js`,
-      module: `../esm5/${alias}/${main}.js`,
-      es2015: `../src/${alias}/${main}.js`,
+      main: `../cjs/${main}`,
+      module: `../esm5/${main}`,
+      es2015: `../src/${main}`,
       sideEffects: false,
     },
   })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 const TerserPlugin = require('terser-webpack-plugin')
+const { ModifySourcePlugin } = require('modify-source-webpack-plugin')
 
 const entry = path.resolve(__dirname, './src/index.js')
 
@@ -31,6 +32,27 @@ module.exports = env => ({
       },
     ],
   },
+  plugins: [
+    new ModifySourcePlugin({
+      rules: [
+        {
+          test: /src\/index\.js$/,
+          modify: src => {
+            return src.replace(
+              /\/\* @replace:umd_imports \(webpack will import all queries and stream api\) \*\//,
+              [
+                "import * as _query from './query'",
+                'export const query = _query',
+
+                "import * as _stream from './stream'",
+                'export const stream = _stream',
+              ].join('\r\n')
+            )
+          },
+        },
+      ],
+    }),
+  ],
   ...(env.analyze && {
     plugins: [
       new BundleAnalyzerPlugin(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,26 +45,26 @@ module.exports = env => ({
                 'export const query = _query',
 
                 "import * as _stream from './stream'",
-                'export const stream = _stream',
+                'export const Stream = _stream',
               ].join('\r\n')
             )
           },
         },
       ],
     }),
+    ...(env.analyze
+      ? [
+          new BundleAnalyzerPlugin(
+            env.stats
+              ? {
+                  analyzerMode: 'disabled',
+                  generateStatsFile: true,
+                }
+              : {}
+          ),
+        ]
+      : []),
   ],
-  ...(env.analyze && {
-    plugins: [
-      new BundleAnalyzerPlugin(
-        env.stats
-          ? {
-              analyzerMode: 'disabled',
-              generateStatsFile: true,
-            }
-          : {}
-      ),
-    ],
-  }),
   optimization: {
     minimize: true,
     minimizer: [new TerserPlugin({ test: /\min.js(\?.*)?$/i })],


### PR DESCRIPTION
### Notes
[DRV-556 Make streaming API independent of Client to not include it into a bundle by default.](https://faunadb.atlassian.net/browse/DRV-556)

Previous stream usage
```
const { Client } = require('faunadb')
const client = new Client();
const stream = client.stream.document(docRef)
```

New usage
```
const { Client, StreamAPI } = require('faunadb')
const client = new Client()
const streamApi = new StreamAPI({ client })
const stream = streamApi.document(docRef)
```
