### PR TITLE
fix: use npm for test running

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
 
       - run:
           name: Install dependencies
-          command: yarn
+          command: npm ci
 
       - save_cache:
           paths:
@@ -51,11 +51,11 @@ commands:
 
       - run:
           name: Test webpack build
-          command: yarn wp
+          command: npm run wp
 
       - run:
           name: Run Tests
-          command: yarn test
+          command: npm run test
 
 jobs:
   core-stable-10:


### PR DESCRIPTION
Repo contains package-lock.json, however, yarn is used to run tests on circleci. 
It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files.