### PR TITLE
DRV-500 - remap 429 HTTP error to TooManyRequests error type.

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -160,6 +160,8 @@ FaunaHTTPError.raiseForStatusCode = function(requestResult) {
         throw new NotFound(requestResult)
       case 405:
         throw new MethodNotAllowed(requestResult)
+      case 429:
+        throw new TooManyRequests(requestResult)
       case 500:
         throw new InternalError(requestResult)
       case 503:
@@ -230,6 +232,18 @@ function MethodNotAllowed(requestResult) {
 }
 
 util.inherits(MethodNotAllowed, FaunaHTTPError)
+
+/**
+ * A HTTP 429 error.
+ * @param {RequestResult} requestResult
+ * @extends module:errors~FaunaHTTPError
+ * @constructor
+ */
+function TooManyRequests(requestResult) {
+  FaunaHTTPError.call(this, 'TooManyRequests', requestResult)
+}
+
+util.inherits(TooManyRequests, FaunaHTTPError)
 
 /**
  * A HTTP 500 error.
@@ -315,6 +329,7 @@ module.exports = {
   PermissionDenied: PermissionDenied,
   NotFound: NotFound,
   MethodNotAllowed: MethodNotAllowed,
+  TooManyRequests: TooManyRequests,
   InternalError: InternalError,
   UnavailableError: UnavailableError,
   StreamError: StreamError,


### PR DESCRIPTION
Remap 429 HTTP error to TooManyRequests error type

### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/DRV-500)

### How to test
Use the following script in order to reproduce `429` error:
```
;(async function () {
  for (const _ of Array(30).fill(null)) {
    await client
      .query(
        Q.CreateIndex({
          name: String(Math.random()),
          source: Q.Collection('items'),
        }),
      )
      .catch(err => {
        console.error(err)
        process.exit(1)
      })
  }

  console.log('Done')
})()
```
Note that `items` collection should have around 200 documents in order to trigger async index creation

### Screenshots
![image](https://user-images.githubusercontent.com/18001933/113288843-20840600-92f8-11eb-878c-c3fd0d5c20dc.png)
