### PR TITLE
DRV-592 - implement inactivity timeout for HTTP2 session

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -155,9 +155,21 @@ var values = require('./values')
  * @param {?fetch} options.fetch
  *   a fetch compatible [API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for making a request
  * @param {?number} options.queryTimeout
- *   Sets the maximum amount of time (in milliseconds) for query execution on the server,
+ *   Sets the maximum amount of time (in milliseconds) for query execution on the server
+ * @param {?number} options.http2SessionIdleTime
+ *   Sets the maximum amount of time (in milliseconds) an HTTP2 session may live
+ *   when there's no activity. Only applicable for NodeJS environment (when http2 module is used), 500 by default,
+ *   can be configured via FAUNADB_HTTP2_SESSION_IDLE_TIME environment variable.
  */
 function Client(options) {
+  var http2SessionIdleTimeEnv = parseInt(
+    util.getEnvVariable('FAUNADB_HTTP2_SESSION_IDLE_TIME'),
+    10
+  )
+  var http2SessionIdleTimeDefault = !isNaN(http2SessionIdleTimeEnv)
+    ? http2SessionIdleTimeEnv
+    : 500
+
   options = util.applyDefaults(options, {
     domain: 'db.fauna.com',
     scheme: 'https',
@@ -169,6 +181,7 @@ function Client(options) {
     headers: {},
     fetch: undefined,
     queryTimeout: null,
+    http2SessionIdleTime: http2SessionIdleTimeDefault,
   })
 
   this._observer = options.observer

--- a/src/_http/index.js
+++ b/src/_http/index.js
@@ -24,7 +24,9 @@ function HttpClient(options) {
   var useHttp2Adapter = !options.fetch && util.isNodeEnv() && isHttp2Supported()
 
   this._adapter = useHttp2Adapter
-    ? new (require('./http2Adapter'))()
+    ? new (require('./http2Adapter'))({
+        http2SessionIdleTime: options.http2SessionIdleTime,
+      })
     : new (require('./fetchAdapter'))({
         isHttps: isHttps,
         fetch: options.fetch,

--- a/src/_util.js
+++ b/src/_util.js
@@ -51,6 +51,25 @@ function isNodeEnv() {
 }
 
 /**
+ * Resolves environment variable if available.
+ *
+ * @param {string} envKey A name of env variable.
+ * @return {void|string} Returns requested env variable or void.
+ * @private
+ */
+function getEnvVariable(envKey) {
+  var areEnvVarsAvailable = !!(
+    typeof process !== 'undefined' &&
+    process &&
+    process.env
+  )
+
+  if (areEnvVarsAvailable && process.env[envKey] != null) {
+    return process.env[envKey]
+  }
+}
+
+/**
  * JavaScript Client Detection
  * @private
  */
@@ -438,6 +457,7 @@ module.exports = {
   querystringify: querystringify,
   inherits: inherits,
   isNodeEnv: isNodeEnv,
+  getEnvVariable: getEnvVariable,
   defaults: defaults,
   applyDefaults: applyDefaults,
   removeNullAndUndefinedValues: removeNullAndUndefinedValues,

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -212,6 +212,23 @@ describe('Client', () => {
     )
   })
 
+  test('http2 session released', async () => {
+    const http2SessionIdleTime = 500
+    const client = util.getClient({
+      http2SessionIdleTime: http2SessionIdleTime,
+    })
+
+    await client.query(query.Now())
+
+    const internalSessionMap = client._http._adapter._sessionMap
+
+    expect(Object.keys(internalSessionMap).length).toBe(1)
+
+    await new Promise(resolve => setTimeout(resolve, http2SessionIdleTime + 1))
+
+    expect(Object.keys(internalSessionMap).length).toBe(0)
+  })
+
   test('Unauthorized error has the proper fields', async () => {
     const client = new Client({ secret: 'bad-key' })
 


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/DRV-592)

### How to test
Can be tested by writing a simple script with a fauna query and assert that after its execution fauna `Client` doesn't hold the event loop (the script is terminated after 500ms).
The following scripts have been used to load test inactivity mechanics by running parallel queries.
Perform `5000` parallel queries over `10` randomly selected `Client` instances:
```typescript
// inactivityTest.ts
require('dotenv').config()
import { Client, query as Q } from 'faunadb'

const SECRET = process.env.FAUNA_SECRET_ADMIN_KEY!

const getRandomInt = (min: number, max: number): number => {
  min = Math.ceil(min)
  max = Math.floor(max)

  return Math.floor(Math.random() * (max - min + 1)) + min
}

const getRandomElement = <T>(list: T[]): T =>
  list[getRandomInt(0, list.length - 1)]

const makeClient = () =>
  new Client({
    secret: SECRET,
    domain: 'db.fauna-preview.com',
    scheme: 'https',
  })

const clientPool = Array.from({ length: 10 }, makeClient)

for (const _ of '_'.repeat(5000)) {
  const client = getRandomElement(clientPool)
  const queries = [
    // Paginate query
    Q.Map(Q.Paginate(Q.Documents(Q.Collection('items'))), ref =>
      Q.Get(ref),
    ),
    // Simple query
    Q.Sum([1, 1]),
  ]

  client.query(getRandomElement(queries)).catch(err => {
    console.error(err)
    process.exit(1)
  })
}
```

To simulate not only parallel queries but also a random delay between them:
```typescript
// inactivityTestWithDelay.ts
require('dotenv').config()
import { Client, query as Q } from 'faunadb'

const IN_PARALLEL = 500
const MAX_ATTEMPTS = 10
const SECRET = process.env.FAUNA_SECRET_ADMIN_KEY!

const getRandomInt = (min: number, max: number): number => {
  min = Math.ceil(min)
  max = Math.floor(max)

  return Math.floor(Math.random() * (max - min + 1)) + min
}

const getRandomElement = <T>(list: T[]): T =>
  list[getRandomInt(0, list.length - 1)]

const makeClient = () =>
  new Client({
    secret: SECRET,
    domain: 'db.fauna-preview.com',
    scheme: 'https',
  })

const clientPool = Array.from({ length: 10 }, makeClient)

const tick = () => {
  const id = Math.random().toString().slice(-5)
  const requests: Promise<unknown>[] = []

  console.log(`Running ${IN_PARALLEL} parallel queries for ${id}`)

  for (const _ of '_'.repeat(IN_PARALLEL)) {
    const client = getRandomElement(clientPool)
    const queries = [
      Q.Map(Q.Paginate(Q.Documents(Q.Collection('items'))), ref =>
        Q.Get(ref),
      ),
      Q.Sum([1, 1]),
    ]

    requests.push(
      client.query(getRandomElement(queries)).catch(err => {
        console.error(err)
        process.exit(1)
      }),
    )
  }

  Promise.all(requests).then(() => console.log(`Done for ${id}`))
}

const execute = (idx = MAX_ATTEMPTS) => {
  const delay = idx === MAX_ATTEMPTS ? 0 : getRandomInt(0, 10 * 1000)

  setTimeout(() => {
    tick()

    if (idx !== 0) {
      execute(idx - 1)
    }
  }, delay)
}

execute()
```