### PR TITLE
Update github link to .io instead of .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A Javascript driver for [FaunaDB](https://fauna.com).
 
-[View reference JSDocs here](https://fauna.github.com/faunadb-js).
+[View reference JSDocs here](https://fauna.github.io/faunadb-js).
 
 See the [FaunaDB Documentation](https://docs.fauna.com/) and
 [Tutorials](https://docs.fauna.com/fauna/current/tutorials/crud) for


### PR DESCRIPTION
### Notes

I tried visiting the FaunaDB JS Driver Reference Documentation link but was displayed this warning:

<img width="1035" alt="Screen Shot 2021-04-08 at 2 17 19 PM" src="https://user-images.githubusercontent.com/12239222/114077664-0ad18c00-9876-11eb-9474-b7c2b692d05b.png">

This PR updates the link in the readme to use .io instead!

### How to test

Visit the link in the README!

### Screenshots

<img width="1035" alt="Screen Shot 2021-04-08 at 2 17 19 PM" src="https://user-images.githubusercontent.com/12239222/114077664-0ad18c00-9876-11eb-9474-b7c2b692d05b.png">
