### PR TITLE
fix: DRV-592 - fix calling onSettled callback twice

### DIFF
--- a/src/_http/http2Adapter.js
+++ b/src/_http/http2Adapter.js
@@ -10,7 +10,7 @@ var STREAM_PREFIX = 'stream::'
  *
  * @constructor
  * @param {object} options Http2Adapter options.
- * @param {number} options.http2SessionIdleTime The time (in milliseconds) that 
+ * @param {number} options.http2SessionIdleTime The time (in milliseconds) that
  * an HTTP2 session may live when there's no activity.
  * @private
  */
@@ -206,7 +206,9 @@ Http2Adapter.prototype.execute = function(options) {
       }
 
       var onEnd = function() {
-        onSettled()
+        if (!isCanceled) {
+          onSettled()
+        }
 
         if (!processStream) {
           return resolve({

--- a/test/util.js
+++ b/test/util.js
@@ -160,6 +160,12 @@ function simulateBrowser() {
   global.navigator = { userAgent: '' } // mock browser navigator
 }
 
+function delay(time) {
+  return new Promise(resolve => {
+    setTimeout(resolve, time)
+  })
+}
+
 module.exports = {
   testConfig: testConfig,
   getCfg: getCfg,
@@ -172,4 +178,5 @@ module.exports = {
   unwrapExpr: unwrapExpr,
   randomString: randomString,
   simulateBrowser: simulateBrowser,
+  delay: delay,
 }


### PR DESCRIPTION
Fixes calling `onSettled` callback twice for streaming requests by taking into account whether the request has already been canceled. The issue was that `onSettled` callback [was called](https://github.com/fauna/faunadb-js/blob/master/src/_http/http2Adapter.js#L209) unconditionally even if the request had already [been canceled](https://github.com/fauna/faunadb-js/blob/master/src/_http/http2Adapter.js#L265) (thus `onSettled` already [been called](https://github.com/fauna/faunadb-js/blob/master/src/_http/http2Adapter.js#L182)) which resulted in [ongoingRequest](https://github.com/fauna/faunadb-js/blob/master/src/_http/http2Adapter.js#L58) to be `-1` and not terminating the stream because [the condition](https://github.com/fauna/faunadb-js/blob/master/src/_http/http2Adapter.js#L100) isn't met (`ongoingRequest` === -1)

### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/DRV-592)

### How to test
* initiate fauna Stream (call `.start` method)
* close the stream
* assert the process is terminated (the event loop is released) after `http2SessionIdleTime` time (500ms by default)