### PR TITLE
DRV-575 - implement Client#close method

### DIFF
--- a/src/_http/index.js
+++ b/src/_http/index.js
@@ -62,6 +62,17 @@ HttpClient.prototype.syncLastTxnTime = function(time) {
 }
 
 /**
+ * Cleans up any held resources.
+ *
+ * @param {?object} opts Close options.
+ * @param {?boolean} opts.force Whether to force resources clean up.
+ * @returns {Promise<void>}
+ */
+HttpClient.prototype.close = function(opts) {
+  return this._adapter.close(opts)
+}
+
+/**
  * Executes an HTTP request.
  *
  * @param {?object} options Request parameters.

--- a/src/errors.js
+++ b/src/errors.js
@@ -319,8 +319,23 @@ function StreamErrorEvent(event) {
 
 util.inherits(StreamErrorEvent, StreamError)
 
+/**
+ * An error thrown when attempting to operate on a closed Client instance.
+ *
+ * @param {string} message The error message.
+ * @param {?string} description The error description.
+ * @extends module:errors~FaunaError
+ * @constructor
+ */
+function ClientClosed(message, description) {
+  FaunaError.call(this, 'ClientClosed', message, description)
+}
+
+util.inherits(ClientClosed, FaunaError)
+
 module.exports = {
   FaunaError: FaunaError,
+  ClientClosed: ClientClosed,
   FaunaHTTPError: FaunaHTTPError,
   InvalidValue: InvalidValue,
   InvalidArity: InvalidArity,

--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -22,6 +22,7 @@ export interface ClientConfig {
   keepAlive?: boolean
   headers?: { [key: string]: string | number }
   fetch?: typeof fetch
+  http2SessionIdleTime?: number
 }
 
 export interface QueryOptions
@@ -46,5 +47,6 @@ export default class Client {
   query<T = object>(expr: ExprArg, options?: QueryOptions): Promise<T>
   paginate(expr: Expr, params?: object, options?: QueryOptions): PageHelper
   ping(scope?: string, timeout?: number): Promise<string>
+  close(opts?: { force?: boolean }): Promise<void>
   stream: StreamApi
 }

--- a/src/types/errors.d.ts
+++ b/src/types/errors.d.ts
@@ -16,6 +16,7 @@ export module errors {
   }
 
   export class InvalidValue extends FaunaError {}
+  export class ClientClosed extends FaunaError {}
   export class FaunaHTTPError extends FaunaError {
     static raiseForStatusCode(requestResult: RequestResult<FaunaHttpErrorResponseContent>): void
 

--- a/test/util.js
+++ b/test/util.js
@@ -144,6 +144,11 @@ function simulateBrowser() {
   global.navigator = { userAgent: '' } // mock browser navigator
 }
 
+function clearBrowserSimulation() {
+  delete global.window
+  delete global.navigator
+}
+
 function delay(time) {
   return new Promise(resolve => {
     setTimeout(resolve, time)
@@ -162,5 +167,6 @@ module.exports = {
   unwrapExpr: unwrapExpr,
   randomString: randomString,
   simulateBrowser: simulateBrowser,
+  clearBrowserSimulation: clearBrowserSimulation,
   delay: delay,
 }


### PR DESCRIPTION
* implement the `Client#close` method to manually clean up an HTTP2 session
* allow `Infinity` for `http2SessionIdleTime` parameter

### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/DRV-575)

### How to test
The following script has been used to test the proper termination:
```typescript
// sample.ts
import { Client, query as Q } from 'faunadb'

const SECRET = process.env.FAUNA_SECRET_ADMIN_KEY!

const client = new Client({
  secret: SECRET,
  domain: 'db.fauna-preview.com',
  scheme: 'https',
  http2SessionIdleTime: Infinity,
})

client.query(Q.Now()).then(console.log)

setTimeout(() => {
  console.log('Force closing...')
  client.close()
}, 5 * 1000)
```

* run `ts-node sample.ts`
* assert script is terminated after around 5secs