### PR TITLE
fix: object with space in key to valid json

### DIFF
--- a/src/Expr.js
+++ b/src/Expr.js
@@ -101,7 +101,7 @@ function printObject(obj) {
     '{' +
     Object.keys(obj)
       .map(function(k) {
-        return k + ': ' + exprToString(obj[k])
+        return '"' + k + '"' + ': ' + exprToString(obj[k])
       })
       .join(', ') +
     '}'

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4,6 +4,7 @@ var errors = require('../src/errors')
 var values = require('../src/values')
 var query = require('../src/query')
 var util = require('./util')
+var Expr = require('../src/Expr')
 var Client = require('../src/Client')
 
 var Ref = query.Ref
@@ -267,6 +268,12 @@ describe('query', () => {
   test('object', () => {
     var obj = query.Object({ x: query.Let({ x: 1 }, query.Var('x')) })
     return assertQuery(obj, { x: 1 })
+  })
+
+  test('object with space in key to valid json', () => {
+    expect(() =>
+      JSON.parse(Expr.toString(query.Object({ 'test key': 1 })))
+    ).not.toThrow()
   })
 
   test('lambda', () => {

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -388,7 +388,7 @@ describe('Values', () => {
 
     assertPrint(
       new Query(q.Lambda('_', q.Paginate(m, { size: 10, after: [20] }))),
-      'Query(Lambda("_", Paginate(Match(Index("idx")), {size: 10, after: [20]})))'
+      'Query(Lambda("_", Paginate(Match(Index("idx")), {"size": 10, "after": [20]})))'
     )
   })
 
@@ -438,7 +438,7 @@ describe('Values', () => {
           product: q.Multiply(q.Var('x'), q.Var('y')),
         })
       ),
-      'Query(Lambda(["x", "y"], {sum: Add(Var("x"), Var("y")), product: Multiply(Var("x"), Var("y"))}))'
+      'Query(Lambda(["x", "y"], {"sum": Add(Var("x"), Var("y")), "product": Multiply(Var("x"), Var("y"))}))'
     )
 
     //returns array
@@ -547,12 +547,12 @@ describe('Values', () => {
     //let expr
     assertPrint(
       new Query(q.Lambda('_', q.Let({ x: 10, y: 20 }, q.Var('x')))),
-      'Query(Lambda("_", Let([{x: 10}, {y: 20}], Var("x"))))'
+      'Query(Lambda("_", Let([{"x": 10}, {"y": 20}], Var("x"))))'
     )
 
     assertPrint(
       new Query(q.Lambda('_', q.Let([{ x: 10 }, { y: 20 }], q.Var('x')))),
-      'Query(Lambda("_", Let([{x: 10}, {y: 20}], Var("x"))))'
+      'Query(Lambda("_", Let([{"x": 10}, {"y": 20}], Var("x"))))'
     )
 
     // filter expr
@@ -603,7 +603,7 @@ describe('Values', () => {
           id: q.Select(['ref', 'id'], q.Var('doc')),
         })
       ),
-      'Query(Merge(Select("data", Var("doc")), {id: Select(["ref", "id"], Var("doc"))}))'
+      'Query(Merge(Select("data", Var("doc")), {"id": Select(["ref", "id"], Var("doc"))}))'
     )
 
     assertPrint(
@@ -616,7 +616,7 @@ describe('Values', () => {
           q.Lambda(['key', 'a', 'b'], q.Var('a'))
         )
       ),
-      'Query(Merge(Select("data", Var("doc")), {id: Select(["ref", "id"], Var("doc"))}, Lambda(["key", "a", "b"], Var("a"))))'
+      'Query(Merge(Select("data", Var("doc")), {"id": Select(["ref", "id"], Var("doc"))}, Lambda(["key", "a", "b"], Var("a"))))'
     )
   })
 
@@ -653,7 +653,7 @@ describe('Values', () => {
   test('pretty print Expr with primitive types', () => {
     assertPrint(
       new Query(q.Lambda('_', { x: true, y: false, z: 'str', w: 10 })),
-      'Query(Lambda("_", {x: true, y: false, z: "str", w: 10}))'
+      'Query(Lambda("_", {"x": true, "y": false, "z": "str", "w": 10}))'
     )
 
     assertPrint(


### PR DESCRIPTION
### Notes
[DRV-482](https://faunadb.atlassian.net/browse/DRV-482)
If document data has a key with space, for example `"my key"`, it would break vs code extension to open such document as it's relly on `toString` implementation of js driver

### How to test
JSON.parse(Expr.toString(query.Object({"my key": 11})))
or
1. insert document with such key to db collection
2. open this doc in vs code extenstion
