### PR TITLE
fix: undefined value in let return an empty object

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -107,7 +107,7 @@ function Let(vars, expr) {
   } else {
     bindings = Object.keys(vars)
       .filter(function(k) {
-        return vars[k]
+        return vars[k] !== undefined
       })
       .map(function(k) {
         var b = {}

--- a/src/query.js
+++ b/src/query.js
@@ -105,11 +105,15 @@ function Let(vars, expr) {
       return wrapValues(item)
     })
   } else {
-    bindings = Object.keys(vars).map(function(k) {
-      var b = {}
-      b[k] = wrap(vars[k])
-      return b
-    })
+    bindings = Object.keys(vars)
+      .filter(function(k) {
+        return vars[k]
+      })
+      .map(function(k) {
+        var b = {}
+        b[k] = wrap(vars[k])
+        return b
+      })
   }
 
   if (typeof expr === 'function') {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -195,6 +195,9 @@ describe('query', () => {
   test('let/var', () => {
     return Promise.all([
       assertQuery(query.Let({ x: 1, test: undefined }, query.Var('x')), 1),
+      assertQuery(query.Let({ x: 1, test: false }, query.Var('test')), false),
+      assertQuery(query.Let({ x: 1, test: 0 }, query.Var('test')), 0),
+      assertQuery(query.Let({ x: 1, test: '' }, query.Var('test')), ''),
       assertQuery(query.Let({ x: 1 }, query.Var('x')), 1),
       assertQuery(
         query.Let({ x: 1, y: 2 }, function(x, y) {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -194,6 +194,7 @@ describe('query', () => {
 
   test('let/var', () => {
     return Promise.all([
+      assertQuery(query.Let({ x: 1, test: undefined }, query.Var('x')), 1),
       assertQuery(query.Let({ x: 1 }, query.Var('x')), 1),
       assertQuery(
         query.Let({ x: 1, y: 2 }, function(x, y) {


### PR DESCRIPTION
### Notes
[DRV-208](https://faunadb.atlassian.net/browse/DRV-208)

Getting `Object expected, Object Provided` error when set a key to undefined.
Because Let does this,
```
Let({ message: "hey", key: undefined }, <expr>)` => `Let([ { message: "hey" }, { } ], <expr>)
```
### How to test
```
query.Let({ x: 1, test: undefined }, query.Var('x')
```