### PR TITLE
fix(types): add signal to query options and TooManyRequests

### DIFF
--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -29,7 +29,9 @@ export interface ClientConfig {
 export interface QueryOptions
   extends Partial<
     Pick<ClientConfig, 'secret' | 'queryTimeout' | 'fetch' | 'observer'>
-  > {}
+  > {
+    signal: AbortSignal
+  }
 
 type StreamFn<T> = (
   expr: Expr,

--- a/src/types/errors.d.ts
+++ b/src/types/errors.d.ts
@@ -33,4 +33,5 @@ export module errors {
   export class MethodNotAllowed extends FaunaHTTPError {}
   export class InternalError extends FaunaHTTPError {}
   export class UnavailableError extends FaunaHTTPError {}
+  export class TooManyRequests extends FaunaHTTPError {}
 }


### PR DESCRIPTION
Add `signal` property to client query option type