### PR TITLE
release: 4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.1
+
+- Make `signal` property of `client.query` optional
+
 ## 4.4.0
 
 - Improve types (errors.pargeJSON, errors.TooManyRequests, `signal` for client.query options)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "apiVersion": "4",
   "description": "FaunaDB Javascript driver for Node.JS and Browsers",
   "homepage": "https://fauna.com",


### PR DESCRIPTION
Make `signal` property of `client.query` optional