### PR TITLE
OSS-906 fix: restore _isFaunaValue and _isFaunaRef properties

### DIFF
--- a/src/values.js
+++ b/src/values.js
@@ -34,9 +34,9 @@ var stringify = nodeUtil ? nodeUtil.inspect : JSON.stringify
  */
 function Value() {}
 
-Value.prototype._isFaunaValue = true
-
 util.inherits(Value, Expr)
+
+Value.prototype._isFaunaValue = true
 
 /**
  * FaunaDB ref.
@@ -60,9 +60,9 @@ function Ref(id, collection, database) {
   if (database) this.value['database'] = database
 }
 
-Ref.prototype._isFaunaRef = true
-
 util.inherits(Ref, Value)
+
+Ref.prototype._isFaunaRef = true
 
 /**
  * Gets the collection part out of the Ref.

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -9,6 +9,7 @@ var q = require('../src/query')
 
 var FaunaDate = values.FaunaDate,
   FaunaTime = values.FaunaTime,
+  Value = values.Value,
   Ref = values.Ref,
   SetRef = values.SetRef,
   Bytes = values.Bytes,
@@ -686,5 +687,19 @@ describe('Values', () => {
       new Query({ lambda: 'X', expr: { var: 'X' }, api_version: '3' }),
       'Query(Lambda("X", Var("X")))'
     )
+  })
+
+  test('type helpers', () => {
+    var expr = new Expr()
+    var value = new Value()
+
+    expect(expr._isFaunaExpr).toEqual(true)
+
+    expect(value._isFaunaExpr).toEqual(true)
+    expect(value._isFaunaValue).toEqual(true)
+
+    expect(ref._isFaunaExpr).toEqual(true)
+    expect(ref._isFaunaValue).toEqual(true)
+    expect(ref._isFaunaRef).toEqual(true)
   })
 })


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/OSS-906)

### How to test
```javascript
var ref = new values.Ref("1234", "things")

 console.log(ref._isFaunaExpr, ref._isFaunaValue, ref._isFaunaRef)

// result should be
true true true
```