### PR TITLE
Hardcode changelog path

### DIFF
--- a/src/_util.js
+++ b/src/_util.js
@@ -527,7 +527,7 @@ function notifyAboutNewVersion() {
               chalk.dim(packageJson.version) +
               chalk.reset(' → ') +
               chalk.green(latestVersion) +
-              `\nChangelog: https://github.com/${packageJson.repository}/blob/main/CHANGELOG.md`,
+              `\nChangelog: https://github.com/fauna/faunadb-js/blob/main/CHANGELOG.md`,
             { padding: 1, borderColor: 'yellow' }
           )
         )


### PR DESCRIPTION
Fixed the changelog path by hardcoding the repository.

Fixes #533.

The path was not displaying properly because, when installing the package with npm, the file `package.json` contains the following:

```
"repository": {
    "type": "git",
    "url": "git+https://github.com/fauna/faunadb-js.git"
  },
```

However, the local `package.json`, when developing on the project, contains the following:

```
"repository": "fauna/faunadb-js",
```

This is likely to be a normalisation transformation performed by npm when installing, which explains why the issue can be observed for users but not for developers.

I made the choice to hardcode the path to the repository because there is no documented substitute field in `package.json` that could contain `fauna/faunadb-js` (other than the homepage, which is already set to `fauna.com`).