### PR TITLE
Add toFQL() to type declaration for Expr

### DIFF
--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -2,5 +2,6 @@ export default class Expr {
   constructor(obj: object)
 
   readonly _isFaunaExpr?: boolean
+  toFQL(): string
   static toString(expr: Expr): string
 }


### PR DESCRIPTION
I wanted to print a query as FQL for debugging purposes, but didn't find the toFQL method because it wasn't in the type declaration. A helpful person on StackOverflow pointed it out to me. https://stackoverflow.com/questions/69418846/how-can-i-print-an-fql-query-from-javascript-as-a-string-e-g-to-test-it-in-the/69472058