### PR TITLE
Change Client.js `checkNewVersion` default

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -171,7 +171,8 @@ var notifyIfNewVersion = notifyAboutNewVersion()
  *   can also be configured via the FAUNADB_HTTP2_SESSION_IDLE_TIME environment variable
  *   which has the highest priority and overrides the option passed into the Client constructor.
  * @param {?boolean} options.checkNewVersion
- *   Enabled by default. Prints a message to the terminal when a newer driver is available.
+ *   Prints a message to the terminal when a newer driver is available.
+ *   Disabled by default. Prints error to console when internet connection is unavailable.
  */
 export default function Client(options) {
   var http2SessionIdleTime = getHttp2SessionIdleTime()
@@ -187,7 +188,7 @@ export default function Client(options) {
     fetch: undefined,
     queryTimeout: null,
     http2SessionIdleTime: http2SessionIdleTime.value,
-    checkNewVersion: true,
+    checkNewVersion: false,
   })
   notifyIfNewVersion(options.checkNewVersion)
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -408,7 +408,7 @@ describe('Client', () => {
       new Client(util.getCfg())
       await new Promise(resolve => {
         setTimeout(() => {
-          expect(console.info.mock.calls[0][0]).not.toContain(
+          expect(console.info.mock.calls[0]).not.toContain(
             'New faunadb version available'
           )
           resolve()

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -414,6 +414,21 @@ describe('Client', () => {
       })
     })
 
+
+    test('enabled through options', async () => {
+      const config = util.getCfg()
+      config.checkNewVersion = true
+      new Client(config)
+      await new Promise(resolve => {
+        setTimeout(() => {
+          expect(console.info.mock.calls[0][0]).toContain(
+            'New faunadb version available'
+          );
+          resolve()
+        }, 0)
+      })
+    })
+
     test('do not print message by default', async () => {
       new Client(util.getCfg())
       new Client(util.getCfg())

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -404,11 +404,11 @@ describe('Client', () => {
       resetNotifyAboutNewVersion()
     })
 
-    test('enabled by default', async () => {
+    test('disabled by default', async () => {
       new Client(util.getCfg())
       await new Promise(resolve => {
         setTimeout(() => {
-          expect(console.info.mock.calls[0][0]).toContain(
+          expect(console.info.mock.calls[0][0]).not.toContain(
             'New faunadb version available'
           )
           resolve()
@@ -416,13 +416,13 @@ describe('Client', () => {
       })
     })
 
-    test('print message only once', async () => {
+    test('do not print message by default', async () => {
       new Client(util.getCfg())
       new Client(util.getCfg())
       new Client(util.getCfg())
       await new Promise(resolve => {
         setTimeout(() => {
-          expect(console.info).toBeCalledTimes(1)
+          expect(console.info).toBeCalledTimes(0)
           resolve()
         }, 0)
       })

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -408,9 +408,7 @@ describe('Client', () => {
       new Client(util.getCfg())
       await new Promise(resolve => {
         setTimeout(() => {
-          expect(console.info.mock.calls[0]).not.toContain(
-            'New faunadb version available'
-          )
+          expect(console.info.mock.calls[0]).toBeUndefined();
           resolve()
         }, 0)
       })


### PR DESCRIPTION
### Notes
[FE-1814]

Currently, the JS driver throws an error if the user is not connected to the internet when testing, which isn't the best user experience. The error is thrown by the FaunaDB client attempting to automatically check for new versions. Updating this to reverse the default version check gives a better user experience.

[FE-1814]: https://faunadb.atlassian.net/browse/FE-1814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ