### PR TITLE
ignore `gh-pages` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,9 @@ workflows:
     #     * Current on 2022-04-19
     #     * Active LTS on 2022-10-25
     #     * Maintenance LTS on 2023-10-18
+    filters:
+      ignore:
+        - gh-pages
     jobs:
       # Stable path
       - core-stable-12:


### PR DESCRIPTION
The CircleCI workflow for the js-drivers attempts to build the gh-pages documentation, even though we're now using Concourse CI to build and publish docs. This PR configures Circle to ignore that branch.