### PR TITLE
inject CircleCI config into `gh-pages`

### DIFF
--- a/concourse/scripts/publish_docs.sh
+++ b/concourse/scripts/publish_docs.sh
@@ -43,5 +43,31 @@ cp -R ../doc/* ./
 git config --global user.email "nobody@concourse-ci.org"
 git config --global user.name "Fauna, Inc"
 
+echo "================================="
+echo "Updating CircleCI to Ignore Build"
+echo "================================="
+
+mkdir .circleci
+cat > config.yml <<- "EOF"
+# No-op workflow for `gh-pages` branch
+version: 2.1
+
+jobs:
+  no-op:
+    docker:
+      - image: circleci/gh-pages
+    steps:
+      - checkout
+
+workflows:
+  no-op:
+    jobs:
+      - no-op:
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+EOF
+
 git add -A
 git commit -m "Update docs to version: $PACKAGE_VERSION"


### PR DESCRIPTION
This PR adds configuration to avoid the consistently/uselessly failing builds for jsdoc. 
Those docs are currently managed via ConcourseCI.

Since the documentation gets regenerated and overwritten on each documentation deploy, the no-op configuration file must be generated and added to the repo before committing.