### PR TITLE
feat: add exports to support bundlers targeting platforms like Cloudflare

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "tools/printReleaseNotes.js"
   ],
   "main": "index.js",
+  "exports": {
+    "require": "./index.js",
+    "default": "./dist/faunadb.js"
+  },
   "scripts": {
     "doc": "jsdoc -c ./jsdoc.json",
     "browserify": "browserify index.js --standalone faunadb -o dist/faunadb.js",


### PR DESCRIPTION
Without this we are forced to import from "faunadb/dist/faunadb" and this sucks when working in TS as there are no types associated with the deep import.

Adding a default field to exports that points to this instead allows us to resolve the proper version when targeting platforms that don't "require()" the module, but rather "import" it.