### PR TITLE
export the stream types from the types file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ export * from './src/types/query';
 export * as query from './src/types/query';
 export * from './src/types/RequestResult';
 export { default as RequestResult } from './src/types/RequestResult';
+export * from './src/types/Stream';
 export * from './src/types/values';
 
 


### PR DESCRIPTION
### Notes
The `index.d.ts` file was missing the export for the `Stream` type declarations, this PR simply adds them as an export to that file.

### How to test
`npm link` this repo to another that imports this module, try to import a stream related type from the `'faunadb'` module (such as `Subscription`) and verify the `Module '"faunadb"' has no exported member 'Subscription'.` error does not appear.

### Screenshots
Before adding the export:
<img width="573" alt="Screenshot 2022-03-19 at 15 47 15" src="https://user-images.githubusercontent.com/1433838/159128492-e81b3ccd-2351-4577-b3e0-12082986061e.png">

After adding the export:
<img width="446" alt="Screenshot 2022-03-19 at 15 58 00" src="https://user-images.githubusercontent.com/1433838/159128515-ee8bf2f0-cb5e-4615-84bd-3e56c5e2bd3c.png">

