### PR TITLE
Propagate Http Errors

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -310,6 +310,10 @@ Client.prototype._execute = function(method, path, data, query, options) {
       })
     )
     .then(function(response) {
+      if(response.status >= 400) {
+        throw new Error(`[HttpError ${response.status}] ${response.body}`)
+      }
+    
       var endTime = Date.now()
       var responseObject = json.parseJSON(response.body)
       var result = new RequestResult(


### PR DESCRIPTION
Http Errors are not being treated, leading to cryptic `SyntaxError: Unexpected end of JSON input` errors.
This PR raises the http error instead of letting it explode somewhere else in the code.
