### PR TITLE
Add :metrics option to capture headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ structured as follows:
   } // usage data
 }
 ```
+Metrics returned in the response will be of `Int` data type.
 #### Pagination Helpers
 
 This driver contains helpers to provide a simpler API for consuming paged

--- a/README.md
+++ b/README.md
@@ -127,6 +127,33 @@ createP.then(function(response) {
 `response` is a JSON object containing the FaunaDB response. See the JSDocs for
 `faunadb.Client`.
 
+The `:metrics` option is used during instantiation to create a client that also 
+returns usage information about the queries issued to FaunaDB.
+
+```javascript
+let client = new faunadb.Client({ 
+  secret: 'YOUR_FAUNADB_SECRET',
+  metrics: true 
+})
+```
+
+The `response` object is shaped differently for clients when the `:metrics` option
+is/not set. The default client setting returns the `response` body at root level. 
+When the client is configured to return `:metrics`, the `response` object is 
+structured as follows:
+
+```javascript
+{
+  value: { ... }, // structured response body
+  metrics: {
+    x-compute-ops: XX,
+    x-byte-read-ops: XX,
+    x-byte-write-ops: XX,
+    x-query-time: XX,
+    x-txn-retries: XX
+  } // usage data
+}
+```
 #### Pagination Helpers
 
 This driver contains helpers to provide a simpler API for consuming paged

--- a/src/Client.js
+++ b/src/Client.js
@@ -326,8 +326,15 @@ Client.prototype._execute = function(method, path, data, query, options) {
         endTime
       )
       self._handleRequestResult(response, result, options)
-
-      return responseObject['resource']
+      
+      if (options.withFaunaMetrics) {
+        return { 
+          response: responseObject['resource'],
+          headers: response.headers
+        }
+      } else {
+        return responseObject['resource']
+      }
     })
 }
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -282,6 +282,22 @@ Client.prototype.close = function(opts) {
   return this._http.close(opts)
 }
 
+/**
+ * Executes a query via the FaunaDB Query API.  
+ * See the [docs](https://app.fauna.com/documentation/reference/queryapi),
+ * and the query functions in this documentation.
+ * @param expression {module:query~ExprArg}
+ *   The query to execute. Created from {@link module:query} functions.
+ * @param {?Object} options
+ *   Object that configures the current query, overriding FaunaDB client options.
+ * @param {?string} options.secret FaunaDB secret (see [Reference Documentation](https://app.fauna.com/documentation/intro/security))
+ * @return {external:Promise<Object>} An object containing the FaunaDB response object and the list of query metrics incurred by the request.
+ */
+ Client.prototype.queryWithMetrics = function(expression, options) {
+  options = Object.assign({}, options, { withMetrics: true })
+  return this._execute('POST', '', query.wrap(expression), null, options)
+}
+
 Client.prototype._execute = function(method, path, data, query, options) {
   query = util.defaults(query, null)
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -356,7 +356,7 @@ Client.prototype._execute = function(method, path, data, query, options) {
         'x-txn-retries'
       ]
 
-      if (options?.metrics) {
+      if (options && options.metrics) {
         return { 
           value: responseObject['resource'],
           metrics:  Object.fromEntries(

--- a/src/Client.js
+++ b/src/Client.js
@@ -165,6 +165,8 @@ var values = require('./values')
  *   which has the highest priority and overrides the option passed into the Client constructor.
  * @param {?boolean} options.checkNewVersion
  *   Enabled by default. Prints a message to the terminal when a newer driver is available.
+ * @param {?boolean} options.metrics
+ *   Disabled by default. Controls whether or not query metrics are returned.
  */
 function Client(options) {
   var http2SessionIdleTime = getHttp2SessionIdleTime()

--- a/src/Client.js
+++ b/src/Client.js
@@ -346,10 +346,10 @@ Client.prototype._execute = function(method, path, data, query, options) {
       self._handleRequestResult(response, result, options)
 
       const metricsHeaders = [
-        'x-query-time',
-        'x-read-ops',
-        'x-write-ops',
         'x-compute-ops',
+        'x-byte-read-ops',
+        'x-byte-write-ops',
+        'x-query-time',
         'x-txn-retries',
       ]
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -361,11 +361,9 @@ Client.prototype._execute = function(method, path, data, query, options) {
       if (options && options.metrics) {
         return {
           value: responseObject['resource'],
-          metrics: Object.fromEntries(
-            Object.entries(response.headers).filter(([key]) =>
-              metricsHeaders.includes(key)
-            )
-          ),
+          metrics: Object.fromEntries(Array.from(Object.entries(response.headers)).
+            map(([ k,v ]) => [k, parseInt(v)]).
+            filter( ([k,v]) => metricsHeaders.includes(k) )),
         }
       } else {
         return responseObject['resource']

--- a/src/Client.js
+++ b/src/Client.js
@@ -291,7 +291,7 @@ Client.prototype.close = function(opts) {
  * @param {?Object} options
  *   Object that configures the current query, overriding FaunaDB client options.
  * @param {?string} options.secret FaunaDB secret (see [Reference Documentation](https://app.fauna.com/documentation/intro/security))
- * @return {external:Promise<Object>} An object containing the FaunaDB response object and the list of query metrics incurred by the request.
+ * @return {external:Promise<Object>} {value, metrics} An object containing the FaunaDB response object and the list of query metrics incurred by the request.
  */
  Client.prototype.queryWithMetrics = function(expression, options) {
   options = Object.assign({}, options, { metrics: true })

--- a/src/Client.js
+++ b/src/Client.js
@@ -294,7 +294,7 @@ Client.prototype.close = function(opts) {
  * @return {external:Promise<Object>} An object containing the FaunaDB response object and the list of query metrics incurred by the request.
  */
  Client.prototype.queryWithMetrics = function(expression, options) {
-  options = Object.assign({}, options, { withMetrics: true })
+  options = Object.assign({}, options, { metrics: true })
   return this._execute('POST', '', query.wrap(expression), null, options)
 }
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -344,15 +344,11 @@ Client.prototype._execute = function(method, path, data, query, options) {
       )
       self._handleRequestResult(response, result, options)
       
-      const metricsHeaders = [ 
-        'x-query-bytes-in', 
-        'x-query-bytes-out', 
-        'x-query-time', 
+      const metricsHeaders = [
+        'x-compute-ops',
         'x-read-ops', 
         'x-write-ops', 
-        'x-compute-ops', 
-        'x-storage-bytes-read', 
-        'x-storage-bytes-write', 
+        'x-query-time', 
         'x-txn-retries'
       ]
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -192,6 +192,7 @@ function Client(options) {
   this._observer = options.observer
   this._http = new http.HttpClient(options)
   this.stream = stream.StreamAPI(this)
+  this.metrics = options.metrics
 }
 
 /**
@@ -356,7 +357,7 @@ Client.prototype._execute = function(method, path, data, query, options) {
         'x-txn-retries',
       ]
 
-      if (options?.metrics) {
+      if (self?.metrics || options?.metrics) {
         return {
           value: responseObject['resource'],
           metrics: Object.fromEntries(

--- a/src/Client.js
+++ b/src/Client.js
@@ -346,14 +346,10 @@ Client.prototype._execute = function(method, path, data, query, options) {
       self._handleRequestResult(response, result, options)
 
       const metricsHeaders = [
-        'x-query-bytes-in',
-        'x-query-bytes-out',
-        'x-query-time',
-        'x-read-ops',
-        'x-write-ops',
         'x-compute-ops',
-        'x-storage-bytes-read',
-        'x-storage-bytes-write',
+        'x-byte-read-ops',
+        'x-byte-write-ops',
+        'x-query-time',
         'x-txn-retries',
       ]
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -362,8 +362,9 @@ Client.prototype._execute = function(method, path, data, query, options) {
         return {
           value: responseObject['resource'],
           metrics: Object.fromEntries(Array.from(Object.entries(response.headers)).
-            map(([ k,v ]) => [k, parseInt(v)]).
-            filter( ([k,v]) => metricsHeaders.includes(k) )),
+            filter( ([k,v]) => metricsHeaders.includes(k) )).
+            map(([ k,v ]) => [k, parseInt(v)])
+            ,
         }
       } else {
         return responseObject['resource']

--- a/src/Client.js
+++ b/src/Client.js
@@ -362,10 +362,9 @@ Client.prototype._execute = function(method, path, data, query, options) {
         return {
           value: responseObject['resource'],
           metrics: Object.fromEntries(Array.from(Object.entries(response.headers)).
-            filter( ([k,v]) => metricsHeaders.includes(k) )).
+            filter( ([k,v]) => metricsHeaders.includes(k) ).
             map(([ k,v ]) => [k, parseInt(v)])
-            ,
-        }
+          )}
       } else {
         return responseObject['resource']
       }

--- a/src/Client.js
+++ b/src/Client.js
@@ -326,11 +326,11 @@ Client.prototype._execute = function(method, path, data, query, options) {
         endTime
       )
       self._handleRequestResult(response, result, options)
-      
-      if (options.withFaunaMetrics) {
-        return { 
+
+      if (options?.withFaunaMetrics) {
+        return {
           response: responseObject['resource'],
-          headers: response.headers
+          headers: response.headers,
         }
       } else {
         return responseObject['resource']

--- a/src/Client.js
+++ b/src/Client.js
@@ -182,6 +182,7 @@ function Client(options) {
     queryTimeout: null,
     http2SessionIdleTime: http2SessionIdleTime.value,
     checkNewVersion: false,
+    metrics: false,
   })
 
   if (http2SessionIdleTime.shouldOverride) {
@@ -327,10 +328,24 @@ Client.prototype._execute = function(method, path, data, query, options) {
       )
       self._handleRequestResult(response, result, options)
       
-      if (options.withFaunaMetrics) {
+      const metricsHeaders = [ 
+        'x-query-bytes-in', 
+        'x-query-bytes-out', 
+        'x-query-time', 
+        'x-read-ops', 
+        'x-write-ops', 
+        'x-compute-ops', 
+        'x-storage-bytes-read', 
+        'x-storage-bytes-write', 
+        'x-txn-retries'
+      ]
+
+      if (options?.metrics) {
         return { 
-          response: responseObject['resource'],
-          headers: response.headers
+          value: responseObject['resource'],
+          metrics:  Object.fromEntries(
+            Object.entries(response.headers).filter(([key]) => metricsHeaders.includes(key))
+          )
         }
       } else {
         return responseObject['resource']

--- a/src/Client.js
+++ b/src/Client.js
@@ -294,7 +294,7 @@ Client.prototype.close = function(opts) {
  * @return {external:Promise<Object>} An object containing the FaunaDB response object and the list of query metrics incurred by the request.
  */
 Client.prototype.queryWithMetrics = function(expression, options) {
-  options = Object.assign({}, options, { withMetrics: true })
+  options = Object.assign({}, options, { metrics: true })
   return this._execute('POST', '', query.wrap(expression), null, options)
 }
 

--- a/src/_util.js
+++ b/src/_util.js
@@ -330,7 +330,7 @@ function getNodeRuntimeEnv() {
  * @param {any} def The default value.
  * @private
  */
-function defaults(obj, def = { withFaunaMetrics: false }) {
+function defaults(obj, def) {
   if (obj === undefined) {
     return def
   } else {

--- a/src/_util.js
+++ b/src/_util.js
@@ -330,7 +330,7 @@ function getNodeRuntimeEnv() {
  * @param {any} def The default value.
  * @private
  */
-function defaults(obj, def) {
+function defaults(obj, def = { withFaunaMetrics: false }) {
   if (obj === undefined) {
     return def
   } else {

--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -24,14 +24,18 @@ export interface ClientConfig {
   fetch?: typeof fetch
   http2SessionIdleTime?: number
   checkNewVersion?: boolean
+  metrics?: boolean
 }
 
 export interface QueryOptions
   extends Partial<
-    Pick<ClientConfig, 'secret' | 'queryTimeout' | 'fetch' | 'observer'>
+    Pick<
+      ClientConfig,
+      'secret' | 'queryTimeout' | 'fetch' | 'observer' | 'metrics'
+    >
   > {
-    signal?: AbortSignal
-  }
+  signal?: AbortSignal
+}
 
 type StreamFn<T> = (
   expr: Expr,

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -40,6 +40,12 @@ describe('Client', () => {
     expect(client._http._baseUrl.endsWith(':0')).toBeFalsy()
   })
 
+  test('returns query metrics if the flag is set', () => {
+    var client = util.getClient({ withFaunaMetrics: true })
+    const response = client.query(query.Add(1, 1))
+    console.log(response)
+  })
+
   test('paginates', () => {
     return createDocument().then(function(document) {
       return client.paginate(document.ref).each(function(page) {
@@ -386,7 +392,6 @@ describe('Client', () => {
       requiredKeys.every(key => driverEnvHeader.includes(key))
     ).toBeDefined()
   })
-
 })
 
 function assertHeader(headers, name) {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -98,12 +98,12 @@ describe('Client', () => {
 
   test('extract response headers from observer', () => {
     var assertResults = function(result) {
-      assertMetric(result.responseHeaders, 'x-read-ops')
-      assertMetric(result.responseHeaders, 'x-write-ops')
-      assertMetric(result.responseHeaders, 'x-storage-bytes-read')
-      assertMetric(result.responseHeaders, 'x-storage-bytes-write')
-      assertMetric(result.responseHeaders, 'x-query-bytes-in')
-      assertMetric(result.responseHeaders, 'x-query-bytes-out')
+      assertObserverStats(result.responseHeaders, 'x-read-ops')
+      assertObserverStats(result.responseHeaders, 'x-write-ops')
+      assertObserverStats(result.responseHeaders, 'x-storage-bytes-read')
+      assertObserverStats(result.responseHeaders, 'x-storage-bytes-write')
+      assertObserverStats(result.responseHeaders, 'x-query-bytes-in')
+      assertObserverStats(result.responseHeaders, 'x-query-bytes-out')
 
       expect(result.endTime).toBeGreaterThan(result.startTime)
     }
@@ -407,9 +407,14 @@ describe('Client', () => {
   })
 })
 
-function assertMetric(metrics, name) {
+function assertObserverStats(metrics, name) {
   expect(metrics[name]).not.toBeNull()
   expect(parseInt(metrics[name])).toBeGreaterThanOrEqual(0)
+}
+
+function assertMetric(metrics, name) {
+  expect(metrics[name]).not.toBeNull()
+  expect(metrics[name]).toBeGreaterThanOrEqual(0)
 }
 
 function createDocument() {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -40,6 +40,27 @@ describe('Client', () => {
     expect(client._http._baseUrl.endsWith(':0')).toBeFalsy()
   })
 
+  test('returns query metrics if the metrics flag is set', async () => {
+    var metricsClient = util.getClient({ metrics: true })
+    const response = await metricsClient.query(query.Add(1, 1))
+    assertMetric(response.metrics, 'x-read-ops')
+    assertMetric(response.metrics, 'x-write-ops')
+    assertMetric(response.metrics, 'x-storage-bytes-read')
+    assertMetric(response.metrics, 'x-storage-bytes-write')
+    assertMetric(response.metrics, 'x-query-bytes-in')
+    assertMetric(response.metrics, 'x-query-bytes-out')
+  })
+
+  test('returns query metrics if using the queryWithMetrics function', async () => {
+    const response = await client.queryWithMetrics(query.Add(1, 1))
+    assertMetric(response.metrics, 'x-read-ops')
+    assertMetric(response.metrics, 'x-write-ops')
+    assertMetric(response.metrics, 'x-storage-bytes-read')
+    assertMetric(response.metrics, 'x-storage-bytes-write')
+    assertMetric(response.metrics, 'x-query-bytes-in')
+    assertMetric(response.metrics, 'x-query-bytes-out')
+  })
+
   test('paginates', () => {
     return createDocument().then(function(document) {
       return client.paginate(document.ref).each(function(page) {
@@ -79,12 +100,12 @@ describe('Client', () => {
 
   test('extract response headers from observer', () => {
     var assertResults = function(result) {
-      assertHeader(result.responseHeaders, 'x-read-ops')
-      assertHeader(result.responseHeaders, 'x-write-ops')
-      assertHeader(result.responseHeaders, 'x-storage-bytes-read')
-      assertHeader(result.responseHeaders, 'x-storage-bytes-write')
-      assertHeader(result.responseHeaders, 'x-query-bytes-in')
-      assertHeader(result.responseHeaders, 'x-query-bytes-out')
+      assertMetric(result.responseHeaders, 'x-read-ops')
+      assertMetric(result.responseHeaders, 'x-write-ops')
+      assertMetric(result.responseHeaders, 'x-storage-bytes-read')
+      assertMetric(result.responseHeaders, 'x-storage-bytes-write')
+      assertMetric(result.responseHeaders, 'x-query-bytes-in')
+      assertMetric(result.responseHeaders, 'x-query-bytes-out')
 
       expect(result.endTime).toBeGreaterThan(result.startTime)
     }
@@ -388,9 +409,9 @@ describe('Client', () => {
   })
 })
 
-function assertHeader(headers, name) {
-  expect(headers[name]).not.toBeNull()
-  expect(parseInt(headers[name])).toBeGreaterThanOrEqual(0)
+function assertMetric(metrics, name) {
+  expect(metrics[name]).not.toBeNull()
+  expect(parseInt(metrics[name])).toBeGreaterThanOrEqual(0)
 }
 
 function createDocument() {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -43,19 +43,19 @@ describe('Client', () => {
   test('returns query metrics if the metrics flag is set', async () => {
     var metricsClient = util.getClient({ metrics: true })
     const response = await metricsClient.query(query.Add(1, 1))
-    assertMetric(response.metrics, 'x-query-time')
-    assertMetric(response.metrics, 'x-read-ops')
-    assertMetric(response.metrics, 'x-write-ops')
     assertMetric(response.metrics, 'x-compute-ops')
+    assertMetric(response.metrics, 'x-byte-read-ops')
+    assertMetric(response.metrics, 'x-byte-write-ops')
+    assertMetric(response.metrics, 'x-query-time')
     assertMetric(response.metrics, 'x-txn-retries')
   })
 
   test('returns query metrics if using the queryWithMetrics function', async () => {
     const response = await client.queryWithMetrics(query.Add(1, 1))
-    assertMetric(response.metrics, 'x-query-time')
-    assertMetric(response.metrics, 'x-read-ops')
-    assertMetric(response.metrics, 'x-write-ops')
     assertMetric(response.metrics, 'x-compute-ops')
+    assertMetric(response.metrics, 'x-byte-read-ops')
+    assertMetric(response.metrics, 'x-byte-write-ops')
+    assertMetric(response.metrics, 'x-query-time')
     assertMetric(response.metrics, 'x-txn-retries')
   })
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -40,12 +40,6 @@ describe('Client', () => {
     expect(client._http._baseUrl.endsWith(':0')).toBeFalsy()
   })
 
-  test('returns query metrics if the flag is set', () => {
-    var client = util.getClient({ metrics: true })
-    const response = client.query(query.Add(1, 1))
-    console.log(response)
-  })
-
   test('paginates', () => {
     return createDocument().then(function(document) {
       return client.paginate(document.ref).each(function(page) {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -59,6 +59,12 @@ describe('Client', () => {
     assertMetric(response.metrics, 'x-txn-retries')
   })
 
+  test('query metrics response has correct structure', async () => {
+    const response = await client.queryWithMetrics(query.Add(1, 1))
+    expect(Object.keys(response).sort()).
+      toEqual(['metrics', 'value'])
+  })
+
   test('paginates', () => {
     return createDocument().then(function(document) {
       return client.paginate(document.ref).each(function(page) {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -65,6 +65,11 @@ describe('Client', () => {
       toEqual(['metrics', 'value'])
   })
 
+  test('client with metrics returns expected value', async () => {
+    const response = await client.queryWithMetrics(query.Add(1, 1))
+    expect(response.value).toEqual(2)
+  })
+
   test('paginates', () => {
     return createDocument().then(function(document) {
       return client.paginate(document.ref).each(function(page) {


### PR DESCRIPTION
### Notes
Current limitations of the JS driver prevent easy access to usage metrics provided in the response headers from the DB. This PR adds a `:metrics` option to allow programmatic access to those metrics.

### How to test
`yarn test`