### PR TITLE
Fix publish_docs script to lazily create .circleci directory

### DIFF
--- a/concourse/scripts/publish_docs.sh
+++ b/concourse/scripts/publish_docs.sh
@@ -47,7 +47,10 @@ echo "================================="
 echo "Updating CircleCI to Ignore Build"
 echo "================================="
 
-mkdir .circleci
+if [ ! -d ".circleci" ]; then
+    mkdir .circleci
+fi
+
 cd .circleci
 cat > config.yml <<- "EOF"
 # No-op workflow for `gh-pages` branch


### PR DESCRIPTION
### Notes

Our concourse pipeline is failing to publish docs because the script that does so is trying to create a directory that was created the last time the script was run.

Updated to lazily create it. This will enable us to slot in any updates to the .circleci configuration controlling the doc publication but not fail the pipeline in the case the directory already exists.

### Testing

Did a very basic shell script test:

```
if [ ! -d "/path/to/dir" ]; then
   echo "It doesn't exist"
fi

if [ ! -d "exists" ]; then
   echo "FAIL!!"
fi
```

To confirm the logic