### PR TITLE
Release npm and docs seperately so that faulty doc publications can be retried. Point at v4 branch

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -16,7 +16,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/fauna/faunadb-js.git
-      branch: main
+      branch: v4
 
   - name: fauna-js-repository-docs
     type: git
@@ -27,7 +27,7 @@ resources:
       private_key: ((fauna/repo.key))
 
 jobs:
-  - name: release
+  - name: release-npm
     serial: true
     public: false
     plan:
@@ -59,6 +59,16 @@ jobs:
           params:
             text_file: slack-message/publish
 
+
+  - name: release-docs
+    serial: true
+    public: false
+    plan:
+      - get: fauna-js-repository
+        passed: [release-npm]
+        trigger: true
+      - get: fauna-js-repository-docs
+        passed: [release-npm]
 
       - task: publish-docs
         file: fauna-js-repository/concourse/tasks/publish-docs.yml


### PR DESCRIPTION
### Notes
Separate doc publication from npm publication in the pipeline in order; enabling retries of doc publication independently of npm publication.