### PR TITLE
Fix backward compatibility bug introduced in 4.5.3 that causes query to return a differnt type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.5.4
+- Disable ability to configure a client and the query method from returning metrics when calling query - fixing bug introduced in 4.5.3 that breaks backward compatibility. Continue supporting queryWithMetrics. [#]().
+
 ## 4.5.3
 - Enable the client to return metrics on queries [#625](https://github.com/fauna/faunadb-js/pull/625) [#628](https://github.com/fauna/faunadb-js/pull/628)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 4.5.4
-- Disable ability to configure a client and the query method from returning metrics when calling query - fixing bug introduced in 4.5.3 that breaks backward compatibility. Continue supporting queryWithMetrics. [#]().
+- Disable ability to configure a client and the query method from returning metrics when calling query - fixing bug introduced in 4.5.3 that breaks backward compatibility. Continue supporting queryWithMetrics. [#633](https://github.com/fauna/faunadb-js/pull/633).
 
 ## 4.5.3
 - Enable the client to return metrics on queries [#625](https://github.com/fauna/faunadb-js/pull/625) [#628](https://github.com/fauna/faunadb-js/pull/628)

--- a/README.md
+++ b/README.md
@@ -137,10 +137,11 @@ let client = new faunadb.Client({
 })
 ```
 
-The `response` object is shaped differently for clients when the `metrics` option
-is/not set. The default client setting returns the `response` body at root level. 
-When the client is configured to return `metrics`, the `response` object is 
-structured as follows:
+#### Querying and Returning the metrics of your queries
+
+The `response` object is shaped differently for clients when calling `queryWithMetrics`;
+it includes the value of the response along with a metrics field giving data on ops,
+time, and transaction retires consumed by your query:
 
 ```javascript
 {

--- a/concourse/scripts/publish.sh
+++ b/concourse/scripts/publish.sh
@@ -19,6 +19,7 @@ then
   echo "Publishing a new version..."
   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
   npm publish
+  npm deprecate faunadb-js@4.5.3 "4.5.3 is is deprecated as it contains a bug that changed the type returned by query for typescript users"
   rm .npmrc
 
   echo "faunadb-js@$PACKAGE_VERSION published to npm" > ../slack-message/publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faunadb",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "faunadb",
-      "version": "4.5.3",
+      "version": "4.5.4",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "apiVersion": "4",
   "description": "FaunaDB Javascript driver for Node.JS and Browsers",
   "homepage": "https://fauna.com",

--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -31,7 +31,7 @@ export interface QueryOptions
   extends Partial<
     Pick<
       ClientConfig,
-      'secret' | 'queryTimeout' | 'fetch' | 'observer' | 'metrics'
+      'secret' | 'queryTimeout' | 'fetch' | 'observer'
     >
   > {
   signal?: AbortSignal

--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -62,7 +62,7 @@ interface MetricsResponse<T = object> {
 
 export default class Client {
   constructor(opts?: ClientConfig)
-  query<T = object>(expr: ExprArg, options?: QueryOptions): Promise<T> | Promise<MetricsResponse<T>>
+  query<T = object>(expr: ExprArg, options?: QueryOptions): Promise<T>
   queryWithMetrics<T = object>(
     expr: ExprArg,
     options?: QueryOptions

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -41,7 +41,7 @@ describe('Client', () => {
   })
 
   test('the client does not support a metrics flag', async () => {
-    expect(util.getClient({ metrics: true })).toThrow(new Error('the client does not support a metrics flag'))
+    expect(() => util.getClient({ metrics: true })).toThrow(new Error('the client does not support a metrics flag'))
   })
 
   test('query does not support a metrics flag', async () => {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -40,18 +40,20 @@ describe('Client', () => {
     expect(client._http._baseUrl.endsWith(':0')).toBeFalsy()
   })
 
-  test('returns query metrics if the metrics flag is set', async () => {
+  test('the client does not support a metrics flag', async () => {
     var metricsClient = util.getClient({ metrics: true })
     const response = await metricsClient.query(query.Add(1, 1))
-    assertMetric(response.metrics, 'x-compute-ops')
-    assertMetric(response.metrics, 'x-byte-read-ops')
-    assertMetric(response.metrics, 'x-byte-write-ops')
-    assertMetric(response.metrics, 'x-query-time')
-    assertMetric(response.metrics, 'x-txn-retries')
+    expect(response).toEqual(2)
   })
 
-  test('returns query metrics if using the queryWithMetrics function', async () => {
+  test('query does not support a metrics flag', async () => {
+    const response = await client.query(query.Add(1, 1))
+    expect(response).toEqual(2)
+  })
+
+  test('queryWithMetrics returns the metrics and the response value', async () => {
     const response = await client.queryWithMetrics(query.Add(1, 1))
+    expect(response.value).toEqual(2)
     assertMetric(response.metrics, 'x-compute-ops')
     assertMetric(response.metrics, 'x-byte-read-ops')
     assertMetric(response.metrics, 'x-byte-write-ops')
@@ -59,16 +61,12 @@ describe('Client', () => {
     assertMetric(response.metrics, 'x-txn-retries')
   })
 
-  test('query metrics response has correct structure', async () => {
+  test('queryWithMetrics returns the metrics', async () => {
     const response = await client.queryWithMetrics(query.Add(1, 1))
     expect(Object.keys(response).sort()).
       toEqual(['metrics', 'value'])
   })
 
-  test('client with metrics returns expected value', async () => {
-    const response = await client.queryWithMetrics(query.Add(1, 1))
-    expect(response.value).toEqual(2)
-  })
 
   test('paginates', () => {
     return createDocument().then(function(document) {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -41,7 +41,7 @@ describe('Client', () => {
   })
 
   test('the client does not support a metrics flag', async () => {
-    expect(() => util.getClient({ metrics: true })).toThrow(new Error('the client does not support a metrics flag'))
+    expect(() => util.getClient({ metrics: true })).toThrow(new Error('No such option metrics'))
   })
 
   test('query does not support a metrics flag', async () => {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -41,9 +41,7 @@ describe('Client', () => {
   })
 
   test('the client does not support a metrics flag', async () => {
-    var metricsClient = util.getClient({ metrics: true })
-    const response = await metricsClient.query(query.Add(1, 1))
-    expect(response).toEqual(2)
+    expect(util.getClient({ metrics: true })).toThrow(new Error('the client does not support a metrics flag'))
   })
 
   test('query does not support a metrics flag', async () => {


### PR DESCRIPTION
### Notes
4.5.3 introduced a bug that broke backward compatibility - it started returning a union of two types on `query` instead of just a single type.

This commit fixes that bug by reverting query to the old interface. It does so by:

- disabling the ability of a user to configure a client such that it always returns metrics on query
- disabling the ability to configure a query call with options to return metrics

Customers will instead need to use queryWithMetrics to get these metrics.

### Testing

Pending circleci