### PR TITLE
Fix non-nullable `Select` default parameter type

### DIFF
--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -197,7 +197,11 @@ export function Tokens(scope?: ExprArg): Expr
 export function Credentials(scope?: ExprArg): Expr
 export function Equals(...args: ExprArg[]): Expr
 export function Contains(path: ExprArg, _in: ExprArg): Expr
-export function Select(path: ExprArg, from: ExprArg, _default?: ExprArg): Expr
+export function Select(
+  path: ExprArg,
+  from: ExprArg,
+  _default?: ExprArg | null
+): Expr
 export function SelectAll(path: ExprArg, from: ExprArg): Expr
 export function Abs(expr: ExprArg): Expr
 export function Add(...args: ExprArg[]): Expr


### PR DESCRIPTION
### Notes

`null` is a valid value in FQL. Fixes #583.

### How to test

1. Pass `null` to the default parameter of [`Select`](https://docs.fauna.com/fauna/current/api/fql/functions/select?lang=javascript). No type error should be raised.

### Screenshots

N/A