### PR TITLE
fix: add missing Native.ROLES type

### DIFF
--- a/src/types/values.d.ts
+++ b/src/types/values.d.ts
@@ -26,6 +26,7 @@ export module values {
     static readonly KEYS: Ref
     static readonly FUNCTIONS: Ref
     static readonly ACCESS_PROVIDERS: Ref
+    static readonly ROLES: Ref
   }
 
   export class SetRef extends Value {


### PR DESCRIPTION
The definition of Native.ROLES is already present in the JS. This PR adds the missing type definition.
