### PR TITLE
CE-177 - when the HTTP2Stream is terminated from the remote server handle the close by cleaning up local state and firing an abort error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "browserify-min": "browserify index.js --standalone faunadb | terser -c -m --keep-fnames --keep-classnames -o dist/faunadb-min.js",
     "prettify": "prettier --write \"{src,test}/**/*.{js,ts}\"",
     "test": "jest --env=node --verbose=true --forceExit ./test",
+    "test-single": "jest --env=node --verbose=true --forceExit",
     "posttest": "node ./test/afterComplete",
     "semantic-release": "semantic-release",
     "wp": "webpack",

--- a/src/_http/http2Adapter.js
+++ b/src/_http/http2Adapter.js
@@ -237,6 +237,12 @@ Http2Adapter.prototype.execute = function(options) {
       rejectOrOnError(new errors.TimeoutError())
     }
 
+    var onClose = function() {
+      isCanceled = true
+      onSettled()
+      rejectOrOnError(new errors.AbortError())
+    }
+
     var onResponse = function(responseHeaders) {
       var status = responseHeaders[http2.constants.HTTP2_HEADER_STATUS]
       var isOkStatus = status >= 200 && status < 400
@@ -301,6 +307,7 @@ Http2Adapter.prototype.execute = function(options) {
         .setEncoding('utf8')
         .on('error', onError)
         .on('response', onResponse)
+        .on('close', onClose)
 
       sessionInterface.onRequestStart()
 

--- a/src/_http/http2Adapter.js
+++ b/src/_http/http2Adapter.js
@@ -238,9 +238,13 @@ Http2Adapter.prototype.execute = function(options) {
     }
 
     var onClose = function() {
-      isCanceled = true
-      onSettled()
-      rejectOrOnError(new errors.AbortError())
+      // See: https://nodejs.org/api/http2.html#event-close_1
+      if (request.rstCode === http2.constants.NGHTTP2_NO_ERROR
+          && request.state.remoteClose === 1) {
+        isCanceled = true
+        onSettled()
+        rejectOrOnError(new errors.AbortError())
+      }
     }
 
     var onResponse = function(responseHeaders) {

--- a/src/_http/index.js
+++ b/src/_http/index.js
@@ -93,7 +93,6 @@ HttpClient.prototype.close = function(opts) {
  * @returns {Promise} The response promise.
  */
 HttpClient.prototype.execute = function(options) {
-  console.log('executing something')
   options = options || {}
 
   var invalidStreamConsumer =

--- a/src/_http/index.js
+++ b/src/_http/index.js
@@ -93,6 +93,7 @@ HttpClient.prototype.close = function(opts) {
  * @returns {Promise} The response promise.
  */
 HttpClient.prototype.execute = function(options) {
+  console.log('executing something')
   options = options || {}
 
   var invalidStreamConsumer =


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/CE-177)

We have implemented an Http2Adapter in the client which wraps up interaction with Node's underlying HTTP2 library: https://nodejs.org/api/http2.html

This code addresses a bug in the wrapper such that:
- When nodes serving customer traffic our spun down processes streaming data can hang as our streaming adapter was not alerting the user via an error that the underlying stream was lost.

This fix addresses this issue by handling [`close` events](https://nodejs.org/api/http2.html#event-close_1) fired off by the [remote server](https://nodejs.org/api/http2.html#http2streamstate) such that our adapter's internal state is appropriately updated.

Note that we should only handle these events if two conditions are met:

1. An `error` event is not being fired (which we can detect via the `rstCode`) (see [here](https://nodejs.org/api/http2.html#event-close_1)
2. The close event is due to the _remote server_ closing the stream; which we can detect via the `state.remoteClose` property. (see [here](https://nodejs.org/api/http2.html#http2streamstate))

### How to test

`yarn test` and also we setup a Lambda to simulate the server remotely closing the connection by spinning up an AWS Lambda querying Fauna on a regular cadence. The Fauna cluster being queried is having its hosts constantly cycled such that we can reproduce the issue. With this change, the scenario now results in an error to the client, rather than a silent hang.

I can provide a link to the integration test in question.