### PR TITLE
Set max session idle time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.6.0
+- Enforce a maximum value of 5000 ms for the `http2SessionIdleTime` option [#642](https://github.com/fauna/faunadb-js/pull/642)
+- Add checks to `http2SessionIdleTime` so that sane defaults are used in case an invalid value is configured
+- Add the missing Native.ROLES type [#638](https://github.com/fauna/faunadb-js/pull/638)
+
 ## 4.5.4
 - Disable ability to configure a client and the query method from returning metrics when calling query - fixing bug introduced in 4.5.3 that breaks backward compatibility. Continue supporting queryWithMetrics. [#633](https://github.com/fauna/faunadb-js/pull/633).
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This Driver supports and is tested on:
 - Node.js [*Current*, *Active LTS*, and *Maintenance LTS* releases](https://nodejs.org/en/about/releases/)
   - *Current* - v17
   - *Active LTS* - currently v16
-  - *Maintenance LTS* - v12 and v14
+  - *Maintenance LTS* - v12 and v14 
 - Chrome
 - Firefox
 - Safari

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ reference](https://docs.fauna.com/fauna/current/api/fql/).
 
 This Driver supports and is tested on:
 
-- Node.js [*Current*, *Active LTS*, and *Maintenance LTS* releases](https://nodejs.org/en/about/releases/)
-  - *Current* - v17
-  - *Active LTS* - currently v16
-  - *Maintenance LTS* - v12 and v14 
+- Node.js [_Current_, _Active LTS_, and _Maintenance LTS_ releases](https://nodejs.org/en/about/releases/)
+  - _Current_ - v17
+  - _Active LTS_ - currently v16
+  - _Maintenance LTS_ - v12 and v14
 - Chrome
 - Firefox
 - Safari
@@ -127,13 +127,13 @@ createP.then(function(response) {
 `response` is a JSON object containing the FaunaDB response. See the JSDocs for
 `faunadb.Client`.
 
-The `metrics` option is used during instantiation to create a client that also 
+The `metrics` option is used during instantiation to create a client that also
 returns usage information about the queries issued to FaunaDB.
 
 ```javascript
-let client = new faunadb.Client({ 
+let client = new faunadb.Client({
   secret: 'YOUR_FAUNADB_SECRET',
-  metrics: true 
+  metrics: true,
 })
 ```
 
@@ -155,7 +155,9 @@ time, and transaction retires consumed by your query:
   } // usage data
 }
 ```
+
 Metrics returned in the response will be of `number` data type.
+
 #### Pagination Helpers
 
 This driver contains helpers to provide a simpler API for consuming paged
@@ -277,17 +279,17 @@ const client = new faunadb.Client({
 When running on the Node.js platform, the Fauna client uses [HTTP/2 multiplexing](https://stackoverflow.com/questions/36517829/what-does-multiplexing-mean-in-http-2)
 to reuse the same session for many simultaneous requests. After all open requests
 have been resolved, the client will keep the session open for a period of time
-(500ms by default) to be reused for any new requests.
+to be reused for any new requests.
 
 The `http2SessionIdleTime` parameter may be used to control how long the HTTP/2
 session remains open while the connection is idle. To save on the overhead of
-closing and re-opening the session, set `http2SessionIdleTime` to a longer time
---- or even `Infinity`, to keep the session alive indefinitely.
+closing and re-opening the session, set `http2SessionIdleTime` to a longer time.
+The default value is 500ms and the maximum value is 5000ms.
 
 While an HTTP/2 session is alive, the client will hold the Node.js event loop
 open; this prevents the process from terminating. Call `Client#close` to manually
 close the session and allow the process to terminate. This is particularly
-important if `http2SessionIdleTime` is long or `Infinity`:
+important if `http2SessionIdleTime` is long:
 
 ```javascript
 // sample.js (run it with "node sample.js" command)
@@ -296,8 +298,8 @@ const { Client, query: Q } = require('faunadb')
 async function main() {
   const client = new Client({
     secret: 'YOUR_FAUNADB_SECRET',
-    http2SessionIdleTime: Infinity,
-    //                    ^^^ Infinity or non-negative integer
+    http2SessionIdleTime: 1000,
+    //                    ^^^ Non-negative integer
   })
   const output = await client.query(Q.Add(1, 1))
 
@@ -309,7 +311,6 @@ async function main() {
 
 main().catch(console.error)
 ```
-
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -282,11 +282,14 @@ have been resolved, the client will keep the session open for a period of time
 (500ms by default) to be reused for any new requests.
 
 The `http2SessionIdleTime` parameter may be used to control how long the HTTP/2
-session remains open while the connection is idle. To save on the overhead of
+session remains open while the query connection is idle. To save on the overhead of
 closing and re-opening the session, set `http2SessionIdleTime` to a longer time.
 The default value is 500ms and the maximum value is 5000ms.
 
-While an HTTP/2 session is alive, the client will hold the Node.js event loop
+Note that `http2SessionIdleTime` has no effect on a stream connection: a stream
+is a long-lived connection that is intended to be held open indefinitely.
+
+While an HTTP/2 session is alive, the client holds the Node.js event loop
 open; this prevents the process from terminating. Call `Client#close` to manually
 close the session and allow the process to terminate. This is particularly
 important if `http2SessionIdleTime` is long:
@@ -298,15 +301,13 @@ const { Client, query: Q } = require('faunadb')
 async function main() {
   const client = new Client({
     secret: 'YOUR_FAUNADB_SECRET',
-    http2SessionIdleTime: 1000,
-    //                    ^^^ Non-negative integer
+    http2SessionIdleTime: 1000, // Must be a non-negative integer
   })
   const output = await client.query(Q.Add(1, 1))
 
   console.log(output)
 
   client.close()
-  //     ^^^ If it's not called then the process won't terminate
 }
 
 main().catch(console.error)

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ reference](https://docs.fauna.com/fauna/current/api/fql/).
 
 This Driver supports and is tested on:
 
-- Node.js [_Current_, _Active LTS_, and _Maintenance LTS_ releases](https://nodejs.org/en/about/releases/)
-  - _Current_ - v17
-  - _Active LTS_ - currently v16
-  - _Maintenance LTS_ - v12 and v14
+- Node.js [*Current*, *Active LTS*, and *Maintenance LTS* releases](https://nodejs.org/en/about/releases/)
+  - *Current* - v17
+  - *Active LTS* - currently v16
+  - *Maintenance LTS* - v12 and v14
 - Chrome
 - Firefox
 - Safari
@@ -127,13 +127,13 @@ createP.then(function(response) {
 `response` is a JSON object containing the FaunaDB response. See the JSDocs for
 `faunadb.Client`.
 
-The `metrics` option is used during instantiation to create a client that also
+The `metrics` option is used during instantiation to create a client that also 
 returns usage information about the queries issued to FaunaDB.
 
 ```javascript
-let client = new faunadb.Client({
+let client = new faunadb.Client({ 
   secret: 'YOUR_FAUNADB_SECRET',
-  metrics: true,
+  metrics: true 
 })
 ```
 
@@ -279,7 +279,7 @@ const client = new faunadb.Client({
 When running on the Node.js platform, the Fauna client uses [HTTP/2 multiplexing](https://stackoverflow.com/questions/36517829/what-does-multiplexing-mean-in-http-2)
 to reuse the same session for many simultaneous requests. After all open requests
 have been resolved, the client will keep the session open for a period of time
-to be reused for any new requests.
+(500ms by default) to be reused for any new requests.
 
 The `http2SessionIdleTime` parameter may be used to control how long the HTTP/2
 session remains open while the connection is idle. To save on the overhead of

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "4.5.4",
+  "version": "4.6.0",
   "apiVersion": "4",
   "description": "FaunaDB Javascript driver for Node.JS and Browsers",
   "homepage": "https://fauna.com",

--- a/src/Client.js
+++ b/src/Client.js
@@ -168,8 +168,9 @@ var values = require('./values')
  *   Disabled by default. Controls whether or not query metrics are returned.
  */
 function Client(options) {
-  const configuredIdleTime = options ? options.http2SessionIdleTime : undefined
-  const http2SessionIdleTime = getHttp2SessionIdleTime(configuredIdleTime)
+  const http2SessionIdleTime = getHttp2SessionIdleTime(
+    options ? options.http2SessionIdleTime : undefined
+  )
 
   if (options) options.http2SessionIdleTime = http2SessionIdleTime
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -159,8 +159,8 @@ var values = require('./values')
  * @param {?number} options.http2SessionIdleTime
  *   Sets the maximum amount of time (in milliseconds) an HTTP2 session may live
  *   when there's no activity. Must be a non-negative integer, with a maximum value of 5000.
- *   If an invalid value is passed a default of 500 ms will be applied. If a value 
- *   exceeding 5000 ms is passed (e.g. Infinity) the maximum of 5000 ms will be applied.
+ *   If an invalid value is passed a default of 500 ms is applied. If a value 
+ *   exceeding 5000 ms is passed (e.g. Infinity) the maximum of 5000 ms is applied.
  *   Only applicable for NodeJS environment (when http2 module is used).
  *   can also be configured via the FAUNADB_HTTP2_SESSION_IDLE_TIME environment variable
  *   which has the highest priority and overrides the option passed into the Client constructor.

--- a/src/Client.js
+++ b/src/Client.js
@@ -394,13 +394,13 @@ function getHttp2SessionIdleTime(configuredIdleTime) {
   // attemp to set the idle time to the env value and then the configured value
   const values = [envIdleTime, configuredIdleTime]
   for (const rawValue of values) {
-    const parsedValue = parseInt(rawValue, 10)
+    const parsedValue = rawValue === 'Infinity'
+      ? Number.MAX_SAFE_INTEGER
+      : parseInt(rawValue, 10)
     const isNegative = parsedValue < 0
-    const isInfinity = rawValue === 'Infinity'
-    const isGreaterThanMax = parsedValue > maxIdleTime || isInfinity
+    const isGreaterThanMax = parsedValue > maxIdleTime
     // if we didn't get infinity or a positive integer move to the next value
-    if (isNegative) continue
-    if (!isInfinity && !parsedValue) continue
+    if (isNegative || !parsedValue) continue
     // if we did get something valid constrain it to the ceiling
     value = parsedValue
     if (isGreaterThanMax) value = maxIdleTime

--- a/src/Client.js
+++ b/src/Client.js
@@ -158,8 +158,10 @@ var values = require('./values')
  *   Sets the maximum amount of time (in milliseconds) for query execution on the server
  * @param {?number} options.http2SessionIdleTime
  *   Sets the maximum amount of time (in milliseconds) an HTTP2 session may live
- *   when there's no activity. Must either be a non-negative integer.
- *   Only applicable for NodeJS environment (when http2 module is used). Default is 500ms;
+ *   when there's no activity. Must be a non-negative integer, with a maximum value of 5000.
+ *   If an invalid value is passed a default of 500 ms will be applied. If a value 
+ *   exceeding 5000 ms is passed (e.g. Infinity) the maximum of 5000 ms will be applied.
+ *   Only applicable for NodeJS environment (when http2 module is used).
  *   can also be configured via the FAUNADB_HTTP2_SESSION_IDLE_TIME environment variable
  *   which has the highest priority and overrides the option passed into the Client constructor.
  * @param {?boolean} options.checkNewVersion
@@ -391,8 +393,7 @@ function getHttp2SessionIdleTime(configuredIdleTime) {
   var value = defaultIdleTime
   // attemp to set the idle time to the env value and then the configured value
   const values = [envIdleTime, configuredIdleTime]
-  for (let i = 0; i <= values.length; i++) {
-    const rawValue = values[i]
+  for (const rawValue of values) {
     const parsedValue = parseInt(rawValue, 10)
     const isNegative = parsedValue < 0
     const isInfinity = rawValue === 'Infinity'
@@ -402,14 +403,7 @@ function getHttp2SessionIdleTime(configuredIdleTime) {
     if (!isInfinity && !parsedValue) continue
     // if we did get something valid constrain it to the ceiling
     value = parsedValue
-    if (isGreaterThanMax) {
-      value = maxIdleTime
-      console.warn(
-        `The value set for http2SessionIdleTime exceeds the maximum value of 
-        ${maxIdleTime} milliseconds. It will be set to ${maxIdleTime} milliseconds instead.`
-      )
-    }
-    
+    if (isGreaterThanMax) value = maxIdleTime
     break
   }
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -168,9 +168,8 @@ var values = require('./values')
  *   Disabled by default. Controls whether or not query metrics are returned.
  */
 function Client(options) {
-  const http2SessionIdleTime = getHttp2SessionIdleTime(
-    options?.http2SessionIdleTime
-  )
+  const configuredIdleTime = options ? options.http2SessionIdleTime : undefined
+  const http2SessionIdleTime = getHttp2SessionIdleTime(configuredIdleTime)
 
   if (options) options.http2SessionIdleTime = http2SessionIdleTime
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -389,7 +389,7 @@ function getHttp2SessionIdleTime(configuredIdleTime) {
   const envIdleTime = util.getEnvVariable('FAUNADB_HTTP2_SESSION_IDLE_TIME')
 
   var value = defaultIdleTime
-  // attemp to set the idle time to the env value and then configured value
+  // attemp to set the idle time to the env value and then the configured value
   const values = [envIdleTime, configuredIdleTime]
   for (let i = 0; i <= values.length; i++) {
     const rawValue = values[i]

--- a/src/Client.js
+++ b/src/Client.js
@@ -296,14 +296,7 @@ Client.prototype.queryWithMetrics = function(expression, options) {
   return this._execute('POST', '', query.wrap(expression), null, options, true)
 }
 
-Client.prototype._execute = function(
-  method,
-  path,
-  data,
-  query,
-  options,
-  returnMetrics = false
-) {
+Client.prototype._execute = function(method, path, data, query, options, returnMetrics = false) {
   query = util.defaults(query, null)
 
   if (
@@ -360,12 +353,10 @@ Client.prototype._execute = function(
       if (returnMetrics) {
         return {
           value: responseObject['resource'],
-          metrics: Object.fromEntries(
-            Array.from(Object.entries(response.headers))
-              .filter(([k, v]) => metricsHeaders.includes(k))
-              .map(([k, v]) => [k, parseInt(v)])
-          ),
-        }
+          metrics: Object.fromEntries(Array.from(Object.entries(response.headers)).
+            filter( ([k,v]) => metricsHeaders.includes(k) ).
+            map(([ k,v ]) => [k, parseInt(v)])
+          )}
       } else {
         return responseObject['resource']
       }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -41,9 +41,7 @@ describe('Client', () => {
   })
 
   test('the client does not support a metrics flag', async () => {
-    expect(() => util.getClient({ metrics: true })).toThrow(
-      new Error('No such option metrics')
-    )
+    expect(() => util.getClient({ metrics: true })).toThrow(new Error('No such option metrics'))
   })
 
   test('query does not support a metrics flag', async () => {
@@ -63,7 +61,8 @@ describe('Client', () => {
 
   test('queryWithMetrics returns the metrics', async () => {
     const response = await client.queryWithMetrics(query.Add(1, 1))
-    expect(Object.keys(response).sort()).toEqual(['metrics', 'value'])
+    expect(Object.keys(response).sort()).
+      toEqual(['metrics', 'value'])
   })
 
   test('paginates', () => {

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -283,10 +283,7 @@ describe('StreamAPI', () => {
       })
       const oldTimestamp = doc.ts
 
-      const assertActiveSessions = length =>
-        expect(Object.keys(client._http._adapter._sessionMap).length).toBe(
-          length
-        )
+      const getNumberOfSessions = () => Object.keys(client._http._adapter._sessionMap).length
 
       stream = client.stream
       .document(doc.ref)
@@ -299,23 +296,24 @@ describe('StreamAPI', () => {
       stream.start()
 
       await util.delay(idleTime + padding)
-      assertActiveSessions(1)
+      expect(getNumberOfSessions()).toBe(1)
 
+      // this will create a new session as it is not a stream
       const { ts: newTimestamp } = await client.query(q.Update(doc.ref, {}))
       expect(newTimestamp).toBeGreaterThan(oldTimestamp)
 
       await util.delay(idleTime + padding)
-      assertActiveSessions(1)
+      expect(getNumberOfSessions()).toBeGreaterThanOrEqual(1)
       expect(seen_event).toBe(true)
 
       seen_event = false
       await util.delay(idleTime + padding)
-      assertActiveSessions(1)
+      expect(getNumberOfSessions()).toBeGreaterThanOrEqual(1)
       expect(seen_event).toBe(false)
 
       stream.close()
       await util.delay(idleTime + padding)
-      assertActiveSessions(0)
+      expect(getNumberOfSessions()).toBe(0)
     }, 30000);
   })
 


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-2238)

Previously "Infinity" was a possible value for `http2SessionIdleTime`. This change enforces a maximum value of `5000` milliseconds.

### How to test
`yarn test`