### PR TITLE
[FE-2558] types for nullable arguments

### DIFF
--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -31,10 +31,7 @@ export function Foreach(
   collection: ExprArg,
   lambda_expr: ExprArg | Lambda
 ): Expr
-export function Filter(
-  collection: ExprArg,
-  lambda_expr: ExprArg | Lambda
-): Expr
+export function Filter(collection: ExprArg, lambda_expr: ExprArg | Lambda): Expr
 export function Take(number: ExprArg, collection: ExprArg): Expr
 export function Drop(number: ExprArg, collection: ExprArg): Expr
 export function Prepend(elements: ExprArg, collection: ExprArg): Expr
@@ -134,11 +131,7 @@ export function LowerCase(expr: ExprArg): Expr
 export function LTrim(expr: ExprArg): Expr
 export function NGram(terms: ExprArg, min?: ExprArg, max?: ExprArg): Expr
 export function Repeat(expr: ExprArg, number?: ExprArg): Expr
-export function ReplaceStr(
-  expr: ExprArg,
-  find: ExprArg,
-  replace: ExprArg
-): Expr
+export function ReplaceStr(expr: ExprArg, find: ExprArg, replace: ExprArg): Expr
 export function ReplaceStrRegex(
   expr: ExprArg,
   find: ExprArg,

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -263,7 +263,7 @@ export function MoveDatabase(from: ExprArg, to: ExprArg): Expr
 export function Documents(collection: ExprArg): Expr
 export function ContainsPath(path: ExprArg, _in: ExprArg): Expr
 export function ContainsField(field: string, _in: ExprArg): Expr
-export function ContainsValue(value: ExprArg | null, _in: ExprArg | null): Expr
+export function ContainsValue(value: ExprArg | null, _in: ExprArg): Expr
 export function Reverse(expr: ExprArg): Expr
 
 export function AccessProvider(name: ExprArg): Expr

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -8,7 +8,7 @@ export function Ref(ref: ExprArg, id?: ExprArg): Expr
 export function Bytes(bytes: ExprArg | ArrayBuffer | Uint8Array): Expr
 export function Abort(msg: ExprArg): Expr
 export function At(timestamp: ExprArg, expr: ExprArg): Expr
-export function Let(vars: ExprArg, in_expr: ExprArg): Expr
+export function Let(vars: ExprArg, in_expr: ExprArg | null): Expr
 export function Var(varName: ExprArg): Expr
 export function If(
   condition: ExprArg,
@@ -38,29 +38,29 @@ export function Prepend(elements: ExprArg, collection: ExprArg): Expr
 export function Append(elements: ExprArg, collection: ExprArg): Expr
 export function IsEmpty(collection: ExprArg): Expr
 export function IsNonEmpty(collection: ExprArg): Expr
-export function IsNumber(expr: ExprArg): Expr
-export function IsDouble(expr: ExprArg): Expr
-export function IsInteger(expr: ExprArg): Expr
-export function IsBoolean(expr: ExprArg): Expr
-export function IsNull(expr: ExprArg): Expr
-export function IsBytes(expr: ExprArg): Expr
-export function IsTimestamp(expr: ExprArg): Expr
-export function IsDate(expr: ExprArg): Expr
-export function IsString(expr: ExprArg): Expr
-export function IsArray(expr: ExprArg): Expr
-export function IsObject(expr: ExprArg): Expr
-export function IsRef(expr: ExprArg): Expr
-export function IsSet(expr: ExprArg): Expr
-export function IsDoc(expr: ExprArg): Expr
-export function IsLambda(expr: ExprArg): Expr
-export function IsCollection(expr: ExprArg): Expr
-export function IsDatabase(expr: ExprArg): Expr
-export function IsIndex(expr: ExprArg): Expr
-export function IsFunction(expr: ExprArg): Expr
-export function IsKey(expr: ExprArg): Expr
-export function IsToken(expr: ExprArg): Expr
-export function IsCredentials(expr: ExprArg): Expr
-export function IsRole(expr: ExprArg): Expr
+export function IsNumber(expr: ExprArg | null): Expr
+export function IsDouble(expr: ExprArg | null): Expr
+export function IsInteger(expr: ExprArg | null): Expr
+export function IsBoolean(expr: ExprArg | null): Expr
+export function IsNull(expr: ExprArg | null): Expr
+export function IsBytes(expr: ExprArg | null): Expr
+export function IsTimestamp(expr: ExprArg | null): Expr
+export function IsDate(expr: ExprArg | null): Expr
+export function IsString(expr: ExprArg | null): Expr
+export function IsArray(expr: ExprArg | null): Expr
+export function IsObject(expr: ExprArg | null): Expr
+export function IsRef(expr: ExprArg | null): Expr
+export function IsSet(expr: ExprArg | null): Expr
+export function IsDoc(expr: ExprArg | null): Expr
+export function IsLambda(expr: ExprArg | null): Expr
+export function IsCollection(expr: ExprArg | null): Expr
+export function IsDatabase(expr: ExprArg | null): Expr
+export function IsIndex(expr: ExprArg | null): Expr
+export function IsFunction(expr: ExprArg | null): Expr
+export function IsKey(expr: ExprArg | null): Expr
+export function IsToken(expr: ExprArg | null): Expr
+export function IsCredentials(expr: ExprArg | null): Expr
+export function IsRole(expr: ExprArg | null): Expr
 
 export function Get(ref: ExprArg, ts?: ExprArg): Expr
 export function KeyFromSecret(secret: ExprArg): Expr
@@ -101,7 +101,11 @@ export function Difference(...sets: ExprArg[]): Expr
 export function Distinct(set: ExprArg): Expr
 export function Join(source: ExprArg, target: ExprArg | Lambda): Expr
 
-export function Range(set: ExprArg, from: ExprArg, to: ExprArg): Expr
+export function Range(
+  set: ExprArg,
+  from: ExprArg | null,
+  to: ExprArg | null
+): Expr
 export function Login(ref: ExprArg, params: ExprArg): Expr
 export function Logout(delete_tokens: ExprArg): Expr
 export function Identify(ref: ExprArg, password: ExprArg): Expr
@@ -188,7 +192,7 @@ export function Roles(scope?: ExprArg): Expr
 export function Keys(scope?: ExprArg): Expr
 export function Tokens(scope?: ExprArg): Expr
 export function Credentials(scope?: ExprArg): Expr
-export function Equals(...args: ExprArg[]): Expr
+export function Equals(...args: (ExprArg | null)[]): Expr
 export function Contains(path: ExprArg, _in: ExprArg): Expr
 export function Select(
   path: ExprArg,
@@ -243,7 +247,7 @@ export function And(...args: ExprArg[]): Expr
 export function Or(...args: ExprArg[]): Expr
 export function Not(bool: ExprArg): Expr
 
-export function ToString(expr: ExprArg): Expr
+export function ToString(expr: ExprArg | null): Expr
 export function ToNumber(expr: ExprArg): Expr
 export function ToObject(expr: ExprArg): Expr
 export function ToArray(expr: ExprArg): Expr
@@ -259,7 +263,7 @@ export function MoveDatabase(from: ExprArg, to: ExprArg): Expr
 export function Documents(collection: ExprArg): Expr
 export function ContainsPath(path: ExprArg, _in: ExprArg): Expr
 export function ContainsField(field: string, _in: ExprArg): Expr
-export function ContainsValue(value: ExprArg, _in: ExprArg): Expr
+export function ContainsValue(value: ExprArg | null, _in: ExprArg | null): Expr
 export function Reverse(expr: ExprArg): Expr
 
 export function AccessProvider(name: ExprArg): Expr


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/jira/software/c/projects/FE/issues/FE-2558)

Makes arguments nullable for the following FQL functions

- `Let` -  `in_expr` can basically be anything.
- `IsNull` - intuitively accepts `null` and returns true.
- all other `IsX` functions - They all accept `null`.
- `Range` - Indexes entries can have null values, so it is important to allow `null`, `[null]` and `[SOMETHING, null]` cursors.
- `Equals` - accepts null values.
- `ToString` - converts `null` to `"null"`.
- `ContainsValue` - can search for `null` in the items of an array or object's properties.