### PR TITLE
[FE-2590] add client endpoint param

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -138,9 +138,9 @@ var values = require('./values')
  * @constructor
  * @param {?Object} options
  *   Object that configures this FaunaDB client.
+ * @param {?string} options.endpoint
+ *   Full URL for the FaunaDB server.
  * @param {?string} options.domain
- *   Base URL for the FaunaDB server.
- * @param {?{ string: string }} options.headers
  *   Base URL for the FaunaDB server.
  * @param {?('http'|'https')} options.scheme
  *   HTTP scheme to use.
@@ -152,6 +152,8 @@ var values = require('./values')
  *   Callback that will be called after every completed request.
  * @param {?boolean} options.keepAlive
  *   Configures http/https keepAlive option (ignored in browser environments)
+ * @param {?{ string: string }} options.headers
+ *   Optional headers to send with requests
  * @param {?fetch} options.fetch
  *   a fetch compatible [API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for making a request
  * @param {?number} options.queryTimeout

--- a/src/Client.js
+++ b/src/Client.js
@@ -161,7 +161,7 @@ var values = require('./values')
  * @param {?number} options.http2SessionIdleTime
  *   Sets the maximum amount of time (in milliseconds) an HTTP2 session may live
  *   when there's no activity. Must be a non-negative integer, with a maximum value of 5000.
- *   If an invalid value is passed a default of 500 ms is applied. If a value 
+ *   If an invalid value is passed a default of 500 ms is applied. If a value
  *   exceeding 5000 ms is passed (e.g. Infinity) the maximum of 5000 ms is applied.
  *   Only applicable for NodeJS environment (when http2 module is used).
  *   can also be configured via the FAUNADB_HTTP2_SESSION_IDLE_TIME environment variable
@@ -303,7 +303,14 @@ Client.prototype.queryWithMetrics = function(expression, options) {
   return this._execute('POST', '', query.wrap(expression), null, options, true)
 }
 
-Client.prototype._execute = function(method, path, data, query, options, returnMetrics = false) {
+Client.prototype._execute = function(
+  method,
+  path,
+  data,
+  query,
+  options,
+  returnMetrics = false
+) {
   query = util.defaults(query, null)
 
   if (
@@ -360,10 +367,12 @@ Client.prototype._execute = function(method, path, data, query, options, returnM
       if (returnMetrics) {
         return {
           value: responseObject['resource'],
-          metrics: Object.fromEntries(Array.from(Object.entries(response.headers)).
-            filter( ([k,v]) => metricsHeaders.includes(k) ).
-            map(([ k,v ]) => [k, parseInt(v)])
-          )}
+          metrics: Object.fromEntries(
+            Array.from(Object.entries(response.headers))
+              .filter(([k, v]) => metricsHeaders.includes(k))
+              .map(([k, v]) => [k, parseInt(v)])
+          ),
+        }
       } else {
         return responseObject['resource']
       }
@@ -397,9 +406,8 @@ function getHttp2SessionIdleTime(configuredIdleTime) {
   // attemp to set the idle time to the env value and then the configured value
   const values = [envIdleTime, configuredIdleTime]
   for (const rawValue of values) {
-    const parsedValue = rawValue === 'Infinity'
-      ? Number.MAX_SAFE_INTEGER
-      : parseInt(rawValue, 10)
+    const parsedValue =
+      rawValue === 'Infinity' ? Number.MAX_SAFE_INTEGER : parseInt(rawValue, 10)
     const isNegative = parsedValue < 0
     const isGreaterThanMax = parsedValue > maxIdleTime
     // if we didn't get infinity or a positive integer move to the next value

--- a/src/Client.js
+++ b/src/Client.js
@@ -177,6 +177,7 @@ function Client(options) {
   if (options) options.http2SessionIdleTime = http2SessionIdleTime
 
   options = util.applyDefaults(options, {
+    endpoint: null,
     domain: 'db.fauna.com',
     scheme: 'https',
     port: null,

--- a/src/_http/index.js
+++ b/src/_http/index.js
@@ -32,7 +32,13 @@ function HttpClient(options) {
         fetch: options.fetch,
         keepAlive: options.keepAlive,
       })
-  this._baseUrl = options.scheme + '://' + options.domain + ':' + options.port
+
+  if (options.endpoint === null) {
+    this._baseUrl = options.scheme + '://' + options.domain + ':' + options.port
+  } else {
+    this._baseUrl = options.endpoint
+  }
+
   this._secret = options.secret
   this._headers = Object.assign({}, options.headers, getDefaultHeaders())
   this._queryTimeout = options.queryTimeout

--- a/src/types/Client.d.ts
+++ b/src/types/Client.d.ts
@@ -10,6 +10,7 @@ type StreamEventFields = 'action' | 'document' | 'diff' | 'prev' | 'index'
 
 export interface ClientConfig {
   secret: string
+  endpoint?: string
   domain?: string
   scheme?: 'http' | 'https'
   port?: number

--- a/test/afterComplete.js
+++ b/test/afterComplete.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const query = require('../src/query')
 const Client = require('../src/Client')
 const util = require('../src/_util')

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -37,6 +37,13 @@ describe('Client', () => {
     })
   })
 
+  test('ping with client configured with "endpoint"', () => {
+    var client = util.getClientFromEndpoint()
+    return client.ping('node').then(function(res) {
+      expect(res).toEqual('Scope node is OK')
+    })
+  })
+
   test("omits the port value if it's falsy", () => {
     const client = new Client({
       secret: 'FAKED',

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -54,7 +54,9 @@ describe('Client', () => {
   })
 
   test('the client does not support a metrics flag', async () => {
-    expect(() => util.getClient({ metrics: true })).toThrow(new Error('No such option metrics'))
+    expect(() => util.getClient({ metrics: true })).toThrow(
+      new Error('No such option metrics')
+    )
   })
 
   test('query does not support a metrics flag', async () => {
@@ -74,8 +76,7 @@ describe('Client', () => {
 
   test('queryWithMetrics returns the metrics', async () => {
     const response = await client.queryWithMetrics(query.Add(1, 1))
-    expect(Object.keys(response).sort()).
-      toEqual(['metrics', 'value'])
+    expect(Object.keys(response).sort()).toEqual(['metrics', 'value'])
   })
 
   test('paginates', () => {
@@ -461,7 +462,7 @@ describe('Client', () => {
 
     process.env.FAUNADB_HTTP2_SESSION_IDLE_TIME = 'Cat'
     client = util.getClient({
-      http2SessionIdleTime: "Cat",
+      http2SessionIdleTime: 'Cat',
     })
     internalIdleTime = client._http._adapter._http2SessionIdleTime
     expect(internalIdleTime).toBe(defaultIdleTime)
@@ -482,7 +483,7 @@ describe('Client', () => {
 
     process.env.FAUNADB_HTTP2_SESSION_IDLE_TIME = '-999'
     client = util.getClient({
-      http2SessionIdleTime: "Infinity",
+      http2SessionIdleTime: 'Infinity',
     })
     internalIdleTime = client._http._adapter._http2SessionIdleTime
     expect(internalIdleTime).toBe(maxIdleTime)

--- a/test/util.js
+++ b/test/util.js
@@ -48,6 +48,24 @@ function getClient(opts) {
   return new Client(objectAssign({ secret: clientSecret }, getCfg(), opts))
 }
 
+function getClientFromEndpoint(opts) {
+  var config = getCfg()
+  var endpoint = config.scheme + '://' + config.domain + ':' + config.port
+
+  return new Client(
+    objectAssign(
+      {
+        secret: clientSecret,
+        endpoint: endpoint,
+        scheme: 'bad scheme',
+        domain: 'bad domain',
+        port: 'bad port',
+      },
+      opts
+    )
+  )
+}
+
 function assertRejected(promise, errorType) {
   var succeeded = false
 
@@ -154,6 +172,7 @@ module.exports = {
   testConfig: testConfig,
   getCfg: getCfg,
   getClient: getClient,
+  getClientFromEndpoint: getClientFromEndpoint,
   assertRejected: assertRejected,
   client: client,
   clientSecret: clientSecret,


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-2590)

The endpoint parameter is supported by other drivers.  Implement it for the JS driver.

Those drivers that support endpoint do not support the scheme + domain + port parameters, so we need to determine how to handle the case where endpoint and the others are included.  My suggestion is that if endpoint is set, then the other three are ignored, and that is what this PR does.

The JS driver accepts and optional argument with override options for the client.query and client.queryWithMetrics methods, but any overrides for  scheme, domain, or port will not have any effect.  No additional checks are required to handle query options.

### Use cases

- The `/linearized` endpoint is not currently useable with the python driver.  Or at least not reasonably.  You can specify the port as `443/linearized` to make it work, but it is not reasonable to advise folks to do  this.
- arbitrary endpoints are not currently possible.  For example if you want to send requests through a proxy.  Again, you can most likely work around this by hacking the `port` parameter.

### How to test
A test was added.  No changes in environment or configuration are required to run the test.
