### PR TITLE
Bump to 4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 4.7.0
 - Support nullable arguments for applicable FQL functions [#651](https://github.com/fauna/faunadb-js/pull/651)
+  and [#36](https://github.com/fauna/faunadb-js/pull/636)
 - Add optional endpoint parameter as an alternative to setting scheme, domain and port individually. The new parameter
   will override scheme, domain and port if set. [#652](https://github.com/fauna/faunadb-js/pull/652)
 - Expose Stream types [#622](https://github.com/fauna/faunadb-js/pull/622)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.7.0
+- Support nullable arguments for applicable FQL functions [#651](https://github.com/fauna/faunadb-js/pull/651)
+- Add optional endpoint parameter as an alternative to setting scheme, domain and port individually. The new parameter
+  will override scheme, domain and port if set. [#652](https://github.com/fauna/faunadb-js/pull/652)
+- Expose Stream types [#622](https://github.com/fauna/faunadb-js/pull/622)
+
 ## 4.6.0
 - Enforce a maximum value of 5000 ms for the `http2SessionIdleTime` option [#642](https://github.com/fauna/faunadb-js/pull/642)
 - Add checks to `http2SessionIdleTime` so that sane defaults are used in case an invalid value is configured
@@ -60,7 +66,7 @@
 ## 4.2.0
 
 - Improve HTTP2 session timeout handling
-- Add the `FAUNADB_HTTP2_SESSION_IDLE_TIME` environment variable  
+- Add the `FAUNADB_HTTP2_SESSION_IDLE_TIME` environment variable
   to specify the default HTTP2 session timeout period
 - Implement a fix for the lack of a `navigator` object in Cloudflare Workers
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "apiVersion": "4",
   "description": "FaunaDB Javascript driver for Node.JS and Browsers",
   "homepage": "https://fauna.com",


### PR DESCRIPTION
### Notes
Bump version to `4.7.0` in preparation for release. 

Here is the [full diff](https://github.com/fauna/faunadb-js/compare/4d8537b4f6cd1cbc205787dad1fa1d4b35d91985..e6bb72e37abf9617d5f69e868a39e526752e57b1) between this release and `4.6.0`.