### PR TITLE
Test that endpoint param can contain trailing slashes

### DIFF
--- a/test/client.test.js
+++ b/test/client.test.js
@@ -44,6 +44,23 @@ describe('Client', () => {
     })
   })
 
+  test('endpoint normalization', async () => {
+    const endpoint = util.getFaunaEndpoint()
+    const endpoints = [
+      endpoint,
+      endpoint + '/',
+      endpoint + '//',
+      endpoint + '\\',
+      endpoint + '\\\\',
+    ]
+    for (const e of endpoints) {
+      var client = new Client({ secret: util.clientSecret, endpoint: e })
+
+      const res = await client.ping('node')
+      expect(res).toEqual('Scope node is OK')
+    }
+  })
+
   test("omits the port value if it's falsy", () => {
     const client = new Client({
       secret: 'FAKED',

--- a/test/util.js
+++ b/test/util.js
@@ -48,9 +48,13 @@ function getClient(opts) {
   return new Client(objectAssign({ secret: clientSecret }, getCfg(), opts))
 }
 
-function getClientFromEndpoint(opts) {
+function getFaunaEndpoint() {
   var config = getCfg()
-  var endpoint = config.scheme + '://' + config.domain + ':' + config.port
+  return config.scheme + '://' + config.domain + ':' + config.port
+}
+
+function getClientFromEndpoint(opts) {
+  var endpoint = getFaunaEndpoint()
 
   return new Client(
     objectAssign(
@@ -172,6 +176,7 @@ module.exports = {
   testConfig: testConfig,
   getCfg: getCfg,
   getClient: getClient,
+  getFaunaEndpoint: getFaunaEndpoint,
   getClientFromEndpoint: getClientFromEndpoint,
   assertRejected: assertRejected,
   client: client,


### PR DESCRIPTION
## Problem

The new endpoint param introduced in #652 should handle trailing slashes (`https://db.fauna.com/` for example).

## Solution

The HTTP adapters already handle this.  We want to make sure we test for it, though.

## Testing

Test ping on clients created using endpoint parameters with trailing slashes.