### PR TITLE
Tag validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ var data = client.query(q.Paginate(q.Collections()), {
   tags: { key1: "value1", key2: "value2" },
 })
 ```
+Both tags and their associated values, must be strings. The only allowable characters are alphanumeric values as well
+as an underscope (_). Max length for keys is 40 characters. Max length for values is 60 characters.
 
 #### Custom Fetch
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "4.6.0",
+  "version": "4.8.0-beta.1",
   "apiVersion": "4",
   "description": "FaunaDB Javascript driver for Node.JS and Browsers",
   "homepage": "https://fauna.com",

--- a/src/_http/index.js
+++ b/src/_http/index.js
@@ -151,12 +151,52 @@ function isValidTraceparentHeader(traceparentHeader) {
 
 function parseTags(tags) {
   if (tags === undefined || tags == null || tags == '') return null
-  if (typeof tags != 'object') {
-    throw new Error('Tags must be provided as an object!')
-  }
+  validateTags(tags)
   return Object.entries(tags)
     .map(e => e.join('='))
     .join(',')
+}
+
+function validateTags(tags) {
+  const maxTagEntries = 25
+  if (typeof tags != 'object') {
+    throw new Error('Tags must be provided as an object!')
+  }
+  if (Object.entries(tags).length > maxTagEntries) {
+    throw new Error('Tags are limited to 25 entries')
+  }
+  validateTagKeys(Object.keys(tags))
+  validateTagValues(Object.values(tags))
+}
+
+function validateTagKeys(keys) {
+  const maxKeyLength = 40
+  keys.forEach(key => {
+    if (typeof key != 'string') {
+      throw new Error(`Provided key, ${key}, must be a string`)
+    } else if (key.length > maxKeyLength) {
+      throw new Error(
+        `Provided key, ${key}, must not exceed maximum length of ${maxKeyLength} characters`
+      )
+    } else if (!/^\w+$/.test(key)) {
+      throw new Error(`Provided key, ${key}, contains invalid characters`)
+    }
+  })
+}
+
+function validateTagValues(values) {
+  const maxValueLength = 80
+  values.forEach(value => {
+    if (typeof value != 'string') {
+      throw new Error(`Provided value, ${value}, must be a string`)
+    } else if (value.length > maxValueLength) {
+      throw new Error(
+        `Provided value, ${value}, must not exceed maximum length of ${maxValueLength} characters`
+      )
+    } else if (!/^\w+$/.test(value)) {
+      throw new Error(`Provided value, ${value}, contains invalid characters`)
+    }
+  })
 }
 
 function secretHeader(secret) {


### PR DESCRIPTION
### Notes
[FE-2693](https://faunadb.atlassian.net/browse/FE-2693)

Note: This will be published to npm as a distinct tag pointed at our incremented version, `4.8.0-beta.1`. This will allow beta customers to download the specific driver version while still allowing us to merge the code back on `v4` afterwards.

### How to test
`yarn test`