### PR TITLE
Force "logbeta" tag in publishConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
     "util": false,
     "boxen": false,
     "chalk": false
+  },
+  "publishConfig": {
+    "tag": "logbeta"
   }
 }


### PR DESCRIPTION
I found [documentation](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#publishconfig) for the `publishConfig` section of `package.json` that allows for overriding the release tag; I figure it would help protect against accidentally publishing as `latest` as happened last time.  We would need to remember to remove it when merging into `v4`.