### PR TITLE
[FE-2781] disallow undefined required args

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -218,6 +218,7 @@ Client.apiVersion = packageJson.apiVersion
  * @return {external:Promise<Object>} FaunaDB response object.
  */
 Client.prototype.query = function(expression, options) {
+  query.arity.between(1, 2, arguments, 'Client.prototype.query')
   options = Object.assign({}, this._globalQueryOptions, options)
   return this._execute('POST', '', query.wrap(expression), null, options)
 }
@@ -300,6 +301,7 @@ Client.prototype.close = function(opts) {
  * @return {external:Promise<Object>} {value, metrics} An object containing the FaunaDB response object and the list of query metrics incurred by the request.
  */
 Client.prototype.queryWithMetrics = function(expression, options) {
+  query.arity.between(1, 2, arguments, 'Client.prototype.query')
   return this._execute('POST', '', query.wrap(expression), null, options, true)
 }
 

--- a/src/query.js
+++ b/src/query.js
@@ -2969,6 +2969,16 @@ function arity(min, max, args, callerFunc) {
   ) {
     throw new errors.InvalidArity(min, max, args.length, callerFunc)
   }
+
+  if (min !== null) {
+    for (let i = 0; i < min; i++) {
+      if (args[i] === undefined) {
+        throw new errors.InvalidValue(
+          `Expected value, but found 'undefined'. Argument ${i} for ${callerFunc} is required.`
+        )
+      }
+    }
+  }
 }
 
 arity.exact = function(n, args, callerFunc) {

--- a/src/query.js
+++ b/src/query.js
@@ -3319,5 +3319,6 @@ module.exports = {
   Documents: Documents,
   Reverse: Reverse,
   AccessProvider: AccessProvider,
+  arity: arity,
   wrap: wrap,
 }

--- a/src/query.js
+++ b/src/query.js
@@ -3041,9 +3041,14 @@ function argsToArray(args) {
  * @private
  */
 function wrap(obj) {
-  arity.exact(1, arguments, wrap.name)
-  if (obj === null) {
-    return null
+  // the arity functions throw when provided undefined arguments
+  // but wrap can accept undefined values. It still should be given
+  // exactly one argument, even if it is undefined.
+  if (arguments.length !== 1) {
+    throw new errors.InvalidArity(1, 1, arguments.length, wrap.name)
+  }
+  if (obj === undefined || obj === null) {
+    return obj
   } else if (
     obj instanceof Expr ||
     util.checkInstanceHasProperty(obj, '_isFaunaExpr')

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3040,6 +3040,22 @@ describe('query', () => {
     }
   })
 
+  test('undfined not allowed as mandatory argument', () => {
+    expect(function() {
+      query.Collection(undefined)
+    }).toThrow()
+  })
+
+  test('optional args can be undefined', () => {
+    expect(function() {
+      query.Select('a', { a: true }, undefined)
+    }).not.toThrow()
+  })
+
+  test('can wrap undefined', () => {
+    expect(query.wrap(undefined)).not.toBeDefined()
+  })
+
   // Helpers
 
   test('varargs', () => {


### PR DESCRIPTION
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-2781)

### Problem

The driver currently validates that the right number of arguments are provided, but it does not validate that the arguments are defined, i.e. `undefined` is a valid value.  For example, the following is possible

```javascript  
client.query(q.Ref(q.Collection(undefined), undefined))
```

which results in wire protocol `{ "ref": {} }`, which is malformed, so the client gets a 400 Bad Request error.

Executing `client.query()` or `client.query(undefined)` also send malformed requests, resulting in 400 responses.

### Notes

The changes are consistent with existing Typescript types and behavior from the service, so this should be an okay patch version change.

Note that `null` is a valid expression, so many arguments may be nullable, but still may not be `undefined`. No change was made to how `null` is handled.

### How to test
tests added

Here's an example script you can run:

```javascript
const run = async () => {
  try {
    const query = q.Ref(q.Collection(undefined), undefined)
    const result = await client.query()
    console.log(result)
  } catch (e) {
    console.error(e)
  }
}
```

**Before**
you get a 400 response with `Request body is not valid JSON.`

**With changes**
you get `InvalidValue: Expected value, but found 'undefined'. Argument 0 for Collection is required.`