### PR TITLE
Bump to 4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.7.1
+- disallow undefined required args [#663](https://github.com/fauna/faunadb-js/pull/663)
+
 ## 4.7.0
 - Support nullable arguments for applicable FQL functions [#651](https://github.com/fauna/faunadb-js/pull/651)
   and [#36](https://github.com/fauna/faunadb-js/pull/636)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "4.6.0",
+  "version": "4.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "apiVersion": "4",
   "description": "FaunaDB Javascript driver for Node.JS and Browsers",
   "homepage": "https://fauna.com",


### PR DESCRIPTION
Bump version in preparation for release.

[Jira Issue](https://faunadb.atlassian.net/browse/FE-2781)

Only one change coming in this release: https://github.com/fauna/faunadb-js/commit/56361d80735a63d6e95b42dae01a69ecb1710de7

* This change enforces argument typing that already existed in the driver but previously wasn't enforced. No doc update should be necessary