### PR TITLE
[FE-2892] fix single ref argument

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -43,6 +43,15 @@ function Ref() {
   arity.between(1, 2, arguments, Ref.name)
   switch (arguments.length) {
     case 1:
+      if (
+        !(typeof arguments[0] === 'string' || arguments[0] instanceof String)
+      ) {
+        throw new errors.InvalidValue(
+          `Expected string, but found ${
+            arguments[0]
+          }. A single argument for Ref must be a string of format \`collections/\${collection_name}/\${id}`
+        )
+      }
       return new Expr({ '@ref': wrap(arguments[0]) })
     case 2:
       return new Expr({ ref: wrap(arguments[0]), id: wrap(arguments[1]) })

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3068,6 +3068,13 @@ describe('query', () => {
     )
     return Promise.all([p1, p2])
   })
+
+  test('single arg to Ref must be a string', () => {
+    expect(() => query.Ref('collections/widgets/123')).not.toThrow()
+    expect(() =>
+      query.Ref(query.Concat(['collections', 'widgets', '123'], '/'))
+    ).toThrow()
+  })
 }, 10000)
 
 function withNewDatabase() {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3056,8 +3056,6 @@ describe('query', () => {
     expect(query.wrap(undefined)).not.toBeDefined()
   })
 
-  // Helpers
-
   test('varargs', () => {
     // Works for lists too
     var p1 = assertQuery(query.Add([2, 3, 5]), 10)
@@ -3076,6 +3074,8 @@ describe('query', () => {
     ).toThrow()
   })
 }, 10000)
+
+// Helpers
 
 function withNewDatabase() {
   return util.rootClient


### PR DESCRIPTION
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-2892)

# Problem

`query.Ref` accepts a single argument for backwards compatibility with the `Ref("collections/widget/123")` format, which is serialized as `{ "@ref": "collections/widget/123" }`.

The driver does this by [just stuffing whatever is given to it as `value => { "@ref": value }`](https://github.com/fauna/faunadb-js/blob/377b174833829a7464b6717e1a2bf6738fa1038b/src/query.js#L46). This is a problem when the value provided is anything other than a string. The database expects FQL values to be... _values_! E.g. is illegal to even provide an expression that resolves to a string

```javascript
client.query(q.Ref(q.Concat(["collections", "widget", "123"], "/"))

// wire protocol
// {"@ref":{"concat":["collections","widget","123"],"separator":"/"}}

{
  "errors": [
    {
	"position": [],
	"code": "invalid expression",
	"description": "Ref expected, Object provided."
    }
  ]
}
```

This error is correct behavior.

## examples of other problematic queries

It is illegal wire protocol for FQL expressions to be in literal values, but is currently allowed

```javascript
const funky_ref = q.Ref(q.Ref(q.Collection("things"), "307286571965481024"))
const funky_wire = JSON.stringify(funky_ref, null, 2)
console.log(funky_wire)

{
  "@ref": {
    "ref": {
      "collection": "things"
    },
    "id": "307286571965481024"
  }
}
```

It there is also potential for folks to wrap a `value.Ref` into another layer of `@ref`, which is problematic.

```javascript
const result = await client.query(q.Ref(q.Collection("things"), "307286571965481024"))
const funky_ref = q.Ref(result)
const funky_wire = JSON.stringify(funky_ref, null, 2)

console.log(funky_wire)
{
  "@ref": {
    "@ref": {
      "id": "307286571965481024",
      "collection": {
        "@ref": {
          "id": "things",
          "collection": {
            "@ref": {
              "id": "collections"
            }
          }
        }
      }
    }
  }
}
```

# Expected behavior

Using `query.Ref` with two arguments, it is expected that the arguments can be any expression 👍🏻 

But if only one argument is provided, we know it must be a string (again, not even an expression that could resolve to a string).

# Solution

Assert that in the single-argument case the argument is a string, i.e. `typeof arguments[0] === 'string' || arguments[0] instanceof String`

# Testing

additional tests added