### PR TITLE
Update Expr.d.ts

### DIFF
--- a/src/types/Expr.d.ts
+++ b/src/types/Expr.d.ts
@@ -3,5 +3,6 @@ export default class Expr {
 
   readonly _isFaunaExpr?: boolean
   toFQL(): string
+  toJSON(): string
   static toString(expr: Expr): string
 }


### PR DESCRIPTION
### Notes
This is a minor proposed change to correct the type definition of the Expr class - Expr.d.ts was missing the `toJSON` function so in typescript environments it wasn't possible to call Expr.toJSON() 

Example below using faunadb-js@4.8.0
![image](https://user-images.githubusercontent.com/5522252/221962472-59dfdea3-e250-4b3d-83e4-f2caa70bc6ac.png)
